### PR TITLE
Don't rely on clang numbering

### DIFF
--- a/Math/mpn_fixed.h
+++ b/Math/mpn_fixed.h
@@ -110,10 +110,10 @@ inline mp_limb_t mpn_add_n_with_carry(mp_limb_t* res, const mp_limb_t* x, const 
         char carry = 0;
         for (int i = 0; i < n; i++)
 #if defined(__clang__)
-#if __clang_major__ < 8 || (defined(__APPLE__) && __clang_major__ < 11)
-            carry = __builtin_ia32_addcarry_u64(carry, x[i], y[i], (unsigned long long*)&res[i]);
-#else
+#if __has_builtin(__builtin_ia32_addcarryx_u64)
             carry = __builtin_ia32_addcarryx_u64(carry, x[i], y[i], (unsigned long long*)&res[i]);
+#else
+            carry = __builtin_ia32_addcarry_u64(carry, x[i], y[i], (unsigned long long*)&res[i]);
 #endif
 #else
             carry = _addcarryx_u64(carry, x[i], y[i], (unsigned long long*)&res[i]);


### PR DESCRIPTION
Apple uses different version numbers from mainline clang. The compiler flag `defined(__APPLE__)` is not a robust way to check which version numbering is used, since on macOS one can also install mainline clang next to the version that comes with the OS.

In particular, this provides a way to compile MP-SPDZ on macOS Sierra (10.12.6). Using stock LLVM (Apple LLVM version 9.0.0, comes with Xcode 9.2 which is the latest supported version) gives a segmentation fault during compile time. Also with GCC there's a problem with the linker. In this situation, installing a newer LLVM, for example using Homebrew, provides a fix.