### PR TITLE
Use Homebrew-installed OpenSSL on macOS for setup-ssl.sh

### DIFF
--- a/Scripts/setup-ssl.sh
+++ b/Scripts/setup-ssl.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# brew-installed OpenSSL on MacOS
+PATH=/usr/local/opt/openssl/bin:$PATH
+
 n=${1:-3}
 
 test -e Player-Data || mkdir Player-Data
@@ -10,6 +13,4 @@ for i in `seq 0 $[n-1]`; do
     openssl req -newkey rsa -nodes -x509 -out Player-Data/P$i.pem -keyout Player-Data/P$i.key -subj "/CN=P$i"
 done
 
-# brew-installed OpenSSL on MacOS
-PATH=$PATH:/usr/local/opt/openssl/bin/
 c_rehash Player-Data


### PR DESCRIPTION
I'm assuming this was the intent of the `PATH` line.