### PR TITLE
Fix: out of range bug in optimizer.run

### DIFF
--- a/Compiler/ml.py
+++ b/Compiler/ml.py
@@ -689,7 +689,7 @@ class Optimizer:
                         indices = indices_by_label[label]
                         @for_range_multithread(self.n_threads, 1, n)
                         def _(i):
-                            idx = indices[i + j * n_per_epoch]
+                            idx = indices[i + j * n]
                             self.layers[0].X[i + label * n] = X[idx]
                     self.forward(None)
                     self.backward()


### PR DESCRIPTION
indices has the shape of n * n_per_epoch in line 681. 
i + j * n_per_epoch did cause an out of range error when n_per_epoch was greater than n.

idx was being filled with the wrong indices groups ([0 ... n] [n_per_epoch ... n_per_epoch + n])

Hope this helps.