### PR TITLE
Take external programs from environment in order to support non FHS distros

### DIFF
--- a/Scripts/bmr-program-run-remote.sh
+++ b/Scripts/bmr-program-run-remote.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 while getopts t: opt; do
     case $opt in

--- a/Scripts/bmr-program-run.sh
+++ b/Scripts/bmr-program-run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 while getopts t: opt; do
     case $opt in

--- a/Scripts/brain.sh
+++ b/Scripts/brain.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 HERE=$(cd `dirname $0`; pwd)
 SPDZROOT=$HERE/..

--- a/Scripts/build.sh
+++ b/Scripts/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function build
 {

--- a/Scripts/ccd.sh
+++ b/Scripts/ccd.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 HERE=$(cd `dirname $0`; pwd)
 SPDZROOT=$HERE/..

--- a/Scripts/chaigear.sh
+++ b/Scripts/chaigear.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 HERE=$(cd `dirname $0`; pwd)
 SPDZROOT=$HERE/..

--- a/Scripts/cowgear.sh
+++ b/Scripts/cowgear.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 HERE=$(cd `dirname $0`; pwd)
 SPDZROOT=$HERE/..

--- a/Scripts/fake-spdz-real-bmr.sh
+++ b/Scripts/fake-spdz-real-bmr.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 HERE=$(cd `dirname $0`; pwd)
 SPDZROOT=$HERE/..

--- a/Scripts/generate-cert.sh
+++ b/Scripts/generate-cert.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 i=$1
 

--- a/Scripts/hemi.sh
+++ b/Scripts/hemi.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 HERE=$(cd `dirname $0`; pwd)
 SPDZROOT=$HERE/..

--- a/Scripts/mal-ccd.sh
+++ b/Scripts/mal-ccd.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 HERE=$(cd `dirname $0`; pwd)
 SPDZROOT=$HERE/..

--- a/Scripts/mal-rep-bin.sh
+++ b/Scripts/mal-rep-bin.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 HERE=$(cd `dirname $0`; pwd)
 SPDZROOT=$HERE/..

--- a/Scripts/mal-rep-bmr.sh
+++ b/Scripts/mal-rep-bmr.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 HERE=$(cd `dirname $0`; pwd)
 SPDZROOT=$HERE/..

--- a/Scripts/mal-rep-field.sh
+++ b/Scripts/mal-rep-field.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 HERE=$(cd `dirname $0`; pwd)
 SPDZROOT=$HERE/..

--- a/Scripts/mal-rep-ring.sh
+++ b/Scripts/mal-rep-ring.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 HERE=$(cd `dirname $0`; pwd)
 SPDZROOT=$HERE/..

--- a/Scripts/mal-shamir-bmr.sh
+++ b/Scripts/mal-shamir-bmr.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 HERE=$(cd `dirname $0`; pwd)
 SPDZROOT=$HERE/..

--- a/Scripts/mal-shamir.sh
+++ b/Scripts/mal-shamir.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 HERE=$(cd `dirname $0`; pwd)
 SPDZROOT=$HERE/..

--- a/Scripts/mama.sh
+++ b/Scripts/mama.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 HERE=$(cd `dirname $0`; pwd)
 SPDZROOT=$HERE/..

--- a/Scripts/mascot.sh
+++ b/Scripts/mascot.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 HERE=$(cd `dirname $0`; pwd)
 SPDZROOT=$HERE/..

--- a/Scripts/ps-rep-field.sh
+++ b/Scripts/ps-rep-field.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 HERE=$(cd `dirname $0`; pwd)
 SPDZROOT=$HERE/..

--- a/Scripts/ps-rep-ring.sh
+++ b/Scripts/ps-rep-ring.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 HERE=$(cd `dirname $0`; pwd)
 SPDZROOT=$HERE/..

--- a/Scripts/real-bmr.sh
+++ b/Scripts/real-bmr.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 HERE=$(cd `dirname $0`; pwd)
 SPDZROOT=$HERE/..

--- a/Scripts/rep-bmr.sh
+++ b/Scripts/rep-bmr.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 HERE=$(cd `dirname $0`; pwd)
 SPDZROOT=$HERE/..

--- a/Scripts/rep-field.sh
+++ b/Scripts/rep-field.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 HERE=$(cd `dirname $0`; pwd)
 SPDZROOT=$HERE/..

--- a/Scripts/replicated.sh
+++ b/Scripts/replicated.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 HERE=$(cd `dirname $0`; pwd)
 SPDZROOT=$HERE/..

--- a/Scripts/ring.sh
+++ b/Scripts/ring.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 HERE=$(cd `dirname $0`; pwd)
 SPDZROOT=$HERE/..

--- a/Scripts/run-online.sh
+++ b/Scripts/run-online.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 HERE=$(cd `dirname $0`; pwd)
 SPDZROOT=$HERE/..

--- a/Scripts/semi-bin.sh
+++ b/Scripts/semi-bin.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 HERE=$(cd `dirname $0`; pwd)
 SPDZROOT=$HERE/..

--- a/Scripts/semi.sh
+++ b/Scripts/semi.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 HERE=$(cd `dirname $0`; pwd)
 SPDZROOT=$HERE/..

--- a/Scripts/semi2k.sh
+++ b/Scripts/semi2k.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 HERE=$(cd `dirname $0`; pwd)
 SPDZROOT=$HERE/..

--- a/Scripts/setup-clients.sh
+++ b/Scripts/setup-clients.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 n=$1
 

--- a/Scripts/setup-online.sh
+++ b/Scripts/setup-online.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 HERE=$(cd `dirname $0`; pwd)
 SPDZROOT=$HERE/..

--- a/Scripts/setup-ssl.sh
+++ b/Scripts/setup-ssl.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # brew-installed OpenSSL on MacOS
 PATH=/usr/local/opt/openssl/bin:$PATH

--- a/Scripts/shamir-bmr.sh
+++ b/Scripts/shamir-bmr.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 HERE=$(cd `dirname $0`; pwd)
 SPDZROOT=$HERE/..

--- a/Scripts/shamir.sh
+++ b/Scripts/shamir.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 HERE=$(cd `dirname $0`; pwd)
 SPDZROOT=$HERE/..

--- a/Scripts/soho.sh
+++ b/Scripts/soho.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 HERE=$(cd `dirname $0`; pwd)
 SPDZROOT=$HERE/..

--- a/Scripts/spdz2k.sh
+++ b/Scripts/spdz2k.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 HERE=$(cd `dirname $0`; pwd)
 SPDZROOT=$HERE/..

--- a/Scripts/test_ecdsa.sh
+++ b/Scripts/test_ecdsa.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 make -j4 ecdsa Fake-ECDSA.x secure.x
 

--- a/Scripts/test_tutorial.sh
+++ b/Scripts/test_tutorial.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 while getopts XYC opt; do
     case $opt in

--- a/Scripts/tinier.sh
+++ b/Scripts/tinier.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 HERE=$(cd `dirname $0`; pwd)
 SPDZROOT=$HERE/..

--- a/Scripts/tiny.sh
+++ b/Scripts/tiny.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 HERE=$(cd `dirname $0`; pwd)
 SPDZROOT=$HERE/..

--- a/Scripts/tldr.sh
+++ b/Scripts/tldr.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 if test `uname` = "Linux"; then
     flags='cat /proc/cpuinfo'
@@ -11,7 +11,7 @@ elif test `uname` = Darwin; then
 	    echo Aborting
 	    exit 1
 	else
-	    /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+	    /usr/bin/env ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 	fi
     fi
     make tldr

--- a/Scripts/yao.sh
+++ b/Scripts/yao.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 . Scripts/run-common.sh
 


### PR DESCRIPTION
For instance, NixOS doesn't follow the FHS.

Note that this PR also updates the SimplOT submodule, because their latest master supports non-FHS.