### PR TITLE
Fix bug preventing accessing sbitvec array using cint

### DIFF
--- a/Programs/Source/test_sbitvec_array.mpc
+++ b/Programs/Source/test_sbitvec_array.mpc
@@ -1,0 +1,10 @@
+sbv64 = sbitvec.get_type(64)
+
+a = Array(4, sbv64)
+
+a[0] = sbv64(1)
+b = a[0]
+
+a[cint(0)] = sbv64(1)
+b = a[cint(0)]
+


### PR DESCRIPTION
Fixes #109 

I am not sure whether this is the correct way to do it but I have mostly tried to replicate the conversion process as in `_register`.

In particular, I am not sure what `get_global_vector_size()` returns and why this would be necessary.