### PR TITLE
Fix missing Compiler/README comment in compiler.py

### DIFF
--- a/compile.py
+++ b/compile.py
@@ -9,8 +9,9 @@
 # Programs/Bytecode/input_file.bc
 # 
 # (run with --help for more options)
-# 
-# See Compiler/README for details on the Compiler package
+#
+# See the compiler documentation at https://mp-spdz.readthedocs.io
+# for details on the Compiler package
 
 
 from optparse import OptionParser


### PR DESCRIPTION
Hi,

 as I was looking through the `compiler.py` file, I noticed there was actually no `Compiler/README` as the comment mentions. This pull request proposes to simply point to the documentation hosted on Read the Docs. An alternative option could be to add a `Compiler/README`. Please let me know if you'd rather do that.

Thanks,
Sylvain