### PR TITLE
bug when building with gmp

### DIFF
--- a/CONFIG
+++ b/CONFIG
@@ -52,6 +52,9 @@ endif
 OS := $(shell uname -s)
 ifeq ($(OS), Linux)
 LDLIBS += -lrt
+ifeq ($(USE_NTL),1)
+LDLIBS += -lgmp
+endif
 endif
 
 ifeq ($(OS), Darwin)


### PR DESCRIPTION
There's a weird bug for building the executables which depend on GMP for linux, for eg when building `chaigear`

```
/usr/bin/ld: ../local/ntl/lib/../lib/libntl.a(lip.o): in function `_ntl_leftrotate(_ntl_gbigint_body**, _ntl_gbigint_body* const*, long, _ntl_gbigint_body*, long, _ntl_gbigint_body**)':
../local/gmp/include/gmp.h:2233: undefined reference to `__gmpn_com'
collect2: error: ld returned 1 exit status
make: *** [Makefile:245: chaigear-party.x] Error 1
```
The fix for this just to add the `lgmp` flag as the last argument in the `LDLIBS`. Fix inspired from: https://stackoverflow.com/a/29054221/2404552