### PR TITLE
Fixed issue when revealing sbitfix Arrays.

### DIFF
--- a/Compiler/GC/types.py
+++ b/Compiler/GC/types.py
@@ -884,7 +884,7 @@ class cbitfix(object):
     malloc = staticmethod(lambda *args: cbits.malloc(*args))
     n_elements = staticmethod(lambda: 1)
     conv = staticmethod(lambda x: x)
-    load_mem = classmethod(lambda cls, *args: cls(cbits.load_mem(*args)))
+    load_mem = classmethod(lambda cls, *args: cls._new(cbits.load_mem(*args)))
     store_in_mem = lambda self, *args: self.v.store_in_mem(*args)
     @classmethod
     def _new(cls, value):


### PR DESCRIPTION
Use of classmethod `_new()` to create a new instance instead of `__init__()` of the previous release.