### PR TITLE
Remove duplicate autoreconf instruction

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -221,7 +221,6 @@ Programs/Circuits:
 mpir-setup:
 	git submodule update --init mpir
 	cd mpir; \
-	autoreconf -i; \
 	autoreconf -i
 	- $(MAKE) -C mpir clean
 


### PR DESCRIPTION
I am assuming that calling `autoreconf` once is sufficient. If I am wrong, I'll learn something :). 