### PR TITLE
Fix a small typo in README on GC

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,8 +478,9 @@ argument to change that.
 
 ### Yao's garbled circuits
 
-We use half-gate garbling as described by [Guo et
-al.](https://eprint.iacr.org/2014/756.pdf). Alternatively, you can
+We use half-gate garbling as described by [Zahur et
+al.](https://eprint.iacr.org/2014/756.pdf) and [Guo et
+al.](https://eprint.iacr.org/2019/1168.pdf). Alternatively, you can
 activate the implementation optimized by [Bellare et
 al.](https://eprint.iacr.org/2013/426) by adding `MY_CFLAGS +=
 -DFULL_GATES` to `CONFIG.mine`.


### PR DESCRIPTION
(Would like to know what is the desired change from you!)

When I was reading the README, I spot that there is a reference to the original half-gate paper, but was cited as Guo et al. 

I assume that you want to refer to the half-gate with the modification for multi-instance security. I made this PR as this is.

```
We use half-gate garbling as described by [Guo et	
al.](https://eprint.iacr.org/2014/756.pdf). Alternatively, you can
```