### PR TITLE
Fix documentation for print_ln_to

### DIFF
--- a/Compiler/library.py
+++ b/Compiler/library.py
@@ -170,7 +170,7 @@ def print_ln_to(player, ss, *args):
 
     Example::
 
-        print_ln_to(player, 'output for %s: %s', player, x.reveal_to(player))
+        print_ln_to(player, 'output for %s: %s', x.reveal_to(player))
     """
     cond = player == get_player_id()
     new_args = []


### PR DESCRIPTION
Removed wrong parameter in documentation from print_ln_to example