### PR TITLE
Fix ignored duplicate registers.

### DIFF
--- a/Compiler/allocator.py
+++ b/Compiler/allocator.py
@@ -180,9 +180,10 @@ def determine_scope(block, options):
     used_from_scope = set_by_id()
 
     def read(reg, n):
-        if last_def[reg] == -1:
-            reg.can_eliminate = False
-            used_from_scope.add(reg)
+        for dup in reg.duplicates:
+            if last_def[dup] == -1:
+                dup.can_eliminate = False
+                used_from_scope.add(dup)
 
     def write(reg, n):
         if last_def[reg] != -1:
@@ -331,8 +332,9 @@ class Merger:
                     d[j] = d[i]
 
         def read(reg, n):
-            if last_def[reg] != -1:
-                add_edge(last_def[reg], n)
+            for dup in reg.duplicates:
+                if last_def[dup] != -1:
+                    add_edge(last_def[dup], n)
 
         def write(reg, n):
             last_def[reg] = n

--- a/Compiler/graph.py
+++ b/Compiler/graph.py
@@ -22,7 +22,7 @@ class SparseDiGraph(object):
         self.default_attributes = default_attributes
         self.attribute_pos = dict(list(zip(list(default_attributes.keys()), list(range(len(default_attributes))))))
         self.n = max_nodes
-        # each node contains list of default attributes, followed by outoing edges
+        # each node contains list of default attributes, followed by outgoing edges
         self.nodes = [list(self.default_attributes.values()) for i in range(self.n)]
         self.succ = [collections.OrderedDict() for i in range(self.n)]
         self.pred = [set() for i in range(self.n)]


### PR DESCRIPTION
The `RegintOptimizer` used in the compiler removes instructions that write to registers, of which the values are known to be equal to previously created registers. This creates equivalence classes, which are stored in the `duplicates` property of registers.
However, this property is not taken into consideration at all necessary positions.

For example, the `Merger`, which decides which instructions to merge with other instructions, ignores `duplicates`, leading to errors: Assume there is the instruction `asm_open 2, c1, s1`, preceded by `mulm s1, s0, c0`, where `c0` is known to be `1`. Then the `RegintOptimizer` removes the `mulm` instruction and puts `s1` together with `s0` into an equivalence class.
The `Merger` tries to find all registers that need to be written to before running `asm_open`. However, it doesn't find anything, because the instruction writing to `s1` has been removed. The fact that `s1` is equivalent to `s0` is simply ignored.
Now, the `asm_open` instruction may be merged with an earlier `asm_open` instruction, even though `s0` has not been initialized at that time.

Here is an example that breaks because of this error:
```
print_ln("%s", (regint(1)*(sint(1)<sint(2))).reveal())
@for_range_opt(1)
def _(i):
    pass
```
The output is 0, but it should be 1.

This commit fixes the error by going through the whole equivalence class when creating an edge in the dependency graph.