### PR TITLE
Fix SubMultiArray.get_addresses for indices without glob

### DIFF
--- a/Compiler/types.py
+++ b/Compiler/types.py
@@ -4980,6 +4980,7 @@ class SubMultiArray(object):
         assert len(indices) == len(self.sizes)
         size = 1
         base = 0
+        skip = 1
         has_glob = False
         last_was_glob = False
         for i, x in enumerate(indices):


### PR DESCRIPTION
Currently, it does not work to call `get_addresses` on a `MultiArray` without a parameter that is `None` (which would represent a glob on a whole dimension of the array). Python terminates with an error, because `skip` is not defined in that case. This problem is fixed by this commit.