### PR TITLE
Adding timeout parameter

### DIFF
--- a/Networking/ServerSocket.cpp
+++ b/Networking/ServerSocket.cpp
@@ -8,6 +8,7 @@
 #include "Tools/Exceptions.h"
 #include "Tools/time-func.h"
 #include "Tools/octetStream.h"
+#include "Processor/OnlineOptions.h"
 
 #include <netinet/ip.h>
 #include <netinet/tcp.h>
@@ -195,8 +196,11 @@ int ServerSocket::get_connection_socket(const string& id)
 
   while (clients.find(id) == clients.end())
   {
-      if (data_signal.wait(60) == ETIMEDOUT)
-          throw runtime_error("No client after one minute");
+      if (data_signal.wait(OnlineOptions::singleton.connection_timeout) == ETIMEDOUT) {
+          stringstream  ss;
+          ss << "No client after " << OnlineOptions::singleton.connection_timeout << " seconds.";
+          throw runtime_error(ss.str());
+      }
   }
 
   int client_socket = clients[id];

--- a/Networking/sockets.cpp
+++ b/Networking/sockets.cpp
@@ -2,6 +2,7 @@
 #include "sockets.h"
 #include "Tools/Exceptions.h"
 #include "Tools/time-func.h"
+#include "Processor/OnlineOptions.h"
 
 #include <iostream>
 #include <fcntl.h>
@@ -101,15 +102,16 @@ void set_up_client_socket(int& mysocket,const char* hostname,int Portnum)
        errno = connect_errno;
    }
    while (fl == -1
-       && (errno == ECONNREFUSED || errno == ETIMEDOUT || errno == EINPROGRESS)
-       && timer.elapsed() < 60);
+       && (errno == ECONNREFUSED || errno == ETIMEDOUT || errno == EINPROGRESS || errno == EHOSTUNREACH)
+       && timer.elapsed() < OnlineOptions::singleton.connection_timeout);
 
    if (fl < 0)
      {
        throw runtime_error(
            string() + "cannot connect from " + my_name + " to " + hostname + ":"
                + to_string(Portnum) + " after " + to_string(attempts)
-               + " attempts in one minute because " + strerror(connect_errno) + ". "
+               + " attempts in " + to_string(OnlineOptions::singleton.connection_timeout) + " seconds because " +
+               strerror(connect_errno) + ". "
                "https://mp-spdz.readthedocs.io/en/latest/troubleshooting.html#"
                "connection-failures has more information on port requirements.");
      }

--- a/Processor/OnlineOptions.cpp
+++ b/Processor/OnlineOptions.cpp
@@ -30,6 +30,9 @@ OnlineOptions::OnlineOptions() : playerno(-1)
     cmd_private_output_file = "";
     file_prep_per_thread = false;
     trunc_error = 40;
+    connection_timeout = 60;
+
+
 #ifdef VERBOSE
     verbose = true;
 #else
@@ -103,6 +106,15 @@ OnlineOptions::OnlineOptions(ez::ezOptionParser& opt, int argc,
             "-B", // Flag token.
             "--bucket-size" // Flag token.
     );
+    opt.add(
+            "60", // Default.
+            0, // Required?
+            1, // Number of args expected.
+            0, // Delimiter if expecting multiple args.
+            "Connection time out in seconds. (default: 60)", // Help description.
+            "-C", // Flag token.
+            "--timeout" // Flag token.
+    );
 
     opt.parse(argc, argv);
 
@@ -112,6 +124,7 @@ OnlineOptions::OnlineOptions(ez::ezOptionParser& opt, int argc,
     opt.get("-OF")->getString(cmd_private_output_file);
 
     opt.get("--bucket-size")->getInt(bucket_size);
+    opt.get("--timeout")->getInt(connection_timeout);
 
 #ifndef VERBOSE
     verbose = opt.isSet("--verbose");

--- a/Processor/OnlineOptions.h
+++ b/Processor/OnlineOptions.h
@@ -31,6 +31,7 @@ public:
     bool verbose;
     bool file_prep_per_thread;
     int trunc_error;
+    int connection_timeout;
 
     OnlineOptions();
     OnlineOptions(ez::ezOptionParser& opt, int argc, const char** argv,

--- a/doc/troubleshooting.rst
+++ b/doc/troubleshooting.rst
@@ -104,6 +104,10 @@ parties. In the default setting, it's 5000 on party 0, and
 ``--my-port``. The scripts in use a random base port number, which you
 can also change with ``--portnumbase``.
 
+When running computations with many (100 or more) parties, the default
+timeout of 60 seconds might be triggered. In this case, you can adjust
+the timeout using the ``--timeout`` parameter.
+
 
 Internally called tape has unknown offline data usage
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
We recently ran into some network connectivity issues when running computations with many (100+) parties, most of which were timeout related. This commit adds a command line parameter that let's the user specify the connection timeout, which also allows
for situations where the user want's to lower the timeout for whatever reason.