### PR TITLE
Add SSL_DIR env var

### DIFF
--- a/CONFIG
+++ b/CONFIG
@@ -8,6 +8,9 @@ GDEBUG = -g
 # set this to your preferred local storage directory
 PREP_DIR = '-DPREP_DIR="Player-Data/"'
 
+# directory to store SSL keys
+SSL_DIR = '-DSSL_DIR="Player-Data/"'
+
 # set for SHE preprocessing (SPDZ and Overdrive)
 USE_NTL = 0
 

--- a/Networking/CryptoPlayer.cpp
+++ b/Networking/CryptoPlayer.cpp
@@ -19,9 +19,9 @@ void ssl_error(string side, string other, string me)
 {
     cerr << side << "-side handshake with " << other
             << " failed. Make sure both sides "
-            << " have the necessary certificate (" << PREP_DIR << me
+            << " have the necessary certificate (" << SSL_DIR << me
             << ".pem in the default configuration on their side and "
-            << PREP_DIR << other << ".pem on ours),"
+            << SSL_DIR << other << ".pem on ours),"
             << " and run `c_rehash <directory>` on its location." << endl
             << "The certificates should be the same on every host. "
             << "Also make sure that it's still valid. Certificates generated "
@@ -36,7 +36,7 @@ void ssl_error(string side, string other, string me)
     cerr << "Signature (should match the other side): ";
     for (int i = 0; i < 2; i++)
     {
-        auto filename = PREP_DIR + ids[i] + ".pem";
+        auto filename = SSL_DIR + ids[i] + ".pem";
         ifstream cert(filename);
         stringstream buffer;
         buffer << cert.rdbuf();

--- a/Networking/ssl_sockets.h
+++ b/Networking/ssl_sockets.h
@@ -14,6 +14,10 @@
 #include <boost/asio.hpp>
 #include <boost/asio/ssl.hpp>
 
+#ifndef SSL_DIR
+#define SSL_DIR "Player-Data/"
+#endif
+
 typedef boost::asio::io_service ssl_service;
 
 void check_ssl_file(string filename);
@@ -25,7 +29,7 @@ public:
     ssl_ctx(string me) :
             boost::asio::ssl::context(boost::asio::ssl::context::tlsv12)
     {
-        string prefix = PREP_DIR + me;
+        string prefix = SSL_DIR + me;
         string cert_file = prefix + ".pem";
         string key_file = prefix + ".key";
         check_ssl_file(cert_file);
@@ -33,7 +37,7 @@ public:
 
         use_certificate_file(cert_file, pem);
         use_private_key_file(key_file, pem);
-        add_verify_path(PREP_DIR);
+        add_verify_path(SSL_DIR);
     }
 };
 

--- a/README.md
+++ b/README.md
@@ -283,6 +283,7 @@ compute the preprocessing time for a particular computation.
    on available options.
  - To benchmark online-only protocols or Overdrive offline phases, add the following line at the top: `MY_CFLAGS = -DINSECURE`
  - `PREP_DIR` should point to a local, unversioned directory to store preprocessing data (the default is `Player-Data` in the current directory).
+ - `SSL_DIR` should point to a local, unversioned directory to store ssl keys (the default is `Player-Data` in the current directory).
  - For homomorphic encryption with GF(2^40), set `USE_NTL = 1`.
 
 2) Run `make` to compile all the software (use the flag `-j` for faster
@@ -707,7 +708,7 @@ information.
 MP-SPDZ uses OpenSSL for secure channels. You can generate the
 necessary certificates and keys as follows:
 
-`Scripts/setup-ssl.sh [<number of parties>]`
+`Scripts/setup-ssl.sh [<number of parties> <SSL_DIR>]`
 
 The programs expect the keys and certificates to be in
 `Player-Data/P<i>.key` and `Player-Data/P<i>.pem`, respectively, and

--- a/Scripts/setup-ssl.sh
+++ b/Scripts/setup-ssl.sh
@@ -4,13 +4,14 @@
 PATH=/usr/local/opt/openssl/bin:$PATH
 
 n=${1:-4}
+ssl_dir=${2:-"Player-Data"}
 
-test -e Player-Data || mkdir Player-Data
+test -e $ssl_dir || mkdir $ssl_dir
 
 echo Setting up SSL for $n parties
 
 for i in `seq 0 $[n-1]`; do
-    openssl req -newkey rsa -nodes -x509 -out Player-Data/P$i.pem -keyout Player-Data/P$i.key -subj "/CN=P$i"
+    openssl req -newkey rsa -nodes -x509 -out $ssl_dir/P$i.pem -keyout $ssl_dir/P$i.key -subj "/CN=P$i"
 done
 
-c_rehash Player-Data
+c_rehash $ssl_dir


### PR DESCRIPTION
The `setup-ssl.sh` script puts the keys under `Player-Data`, meanwhile the `CryptoPlayer` expects the keys to be under `PREP_DIR`. This works fine as long as `PREP_DIR` is the default `Player-Data` but when using a preprocessing directory other than `Player-Data`, the keys must be moved from `Player-Data`.

The proposed changes allow for setting a specific directory for SSL keys, and defaults to `Player-Data` if not set. The `setup-ssl.sh` is also modified to take on a parameter specifying a custom location.

The motivation for having a dedicated SSL directory is for deployments, in which it may make sense, for security reasons for instance, to put keys, in a different location.

