### PR TITLE
Add .env to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,6 @@ Thumbs.db
 
 # Sphinx build
 _build/
+
+# environment
+.env


### PR DESCRIPTION
`.env` is useful to configure one's own development environment.