### PR TITLE
Make cint.digest compute digest on vector

### DIFF
--- a/Compiler/types.py
+++ b/Compiler/types.py
@@ -1156,8 +1156,9 @@ class cint(_clear, _int):
 
     def digest(self, num_bytes):
         """ Clear hashing (libsodium default). """
-        res = cint()
-        digestc(res, self, num_bytes)
+        res = cint(size=self.size)
+        for i in range(self.size):
+            digestc(res[i], self[i], num_bytes)
         return res
 
     def print_if(self, string):


### PR DESCRIPTION
Hi,

I noticed that `cint.digest` only computes the digest for the first entry in the `cint`, if `cint` has size > 1. This PR should fix that on the compiler level, i.e. it generates one digest instruction for each vector entry.

```
a = cint([0,1], size=2)

b = a.digest(16)

print_ln('%s', b.reveal())
```
Now properly prints two values.