### PR TITLE
Update Makefile for macs where Homebrew is installed in non-traditional locations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -294,8 +294,8 @@ mpir: mpir-setup
 
 mac-setup: mac-machine-setup
 	brew install openssl boost libsodium mpir yasm ntl
-	-echo MY_CFLAGS += -I/usr/local/opt/openssl/include -I/opt/homebrew/opt/openssl/include -I/opt/homebrew/include >> CONFIG.mine
-	-echo MY_LDLIBS += -L/usr/local/opt/openssl/lib -L/opt/homebrew/lib -L/opt/homebrew/opt/openssl/lib >> CONFIG.mine
+	-echo MY_CFLAGS += -I/usr/local/opt/openssl/include -I`brew --prefix`/opt/openssl/include -I`brew --prefix`/include >> CONFIG.mine
+	-echo MY_LDLIBS += -L/usr/local/opt/openssl/lib -L`brew --prefix`/lib -L`brew --prefix`/opt/openssl/lib >> CONFIG.mine
 #	-echo USE_NTL = 1 >> CONFIG.mine
 
 ifeq ($(MACHINE), aarch64)


### PR DESCRIPTION
The Makefile currently assumes that Homebrew is installed at `/opt/homebrew`, but in some cases, it can be installed elsewhere. (This is especially acute for managed machines.)

`brew --prefix` will provide where Homebrew is installed, so this uses that and should be compatible with any install location.