### PR TITLE
Sorting import bug

### DIFF
--- a/Compiler/types.py
+++ b/Compiler/types.py
@@ -5657,7 +5657,7 @@ class Array(_vectorizable):
             if n_threads or 1 > 1:
                 raise CompilerError('multi-threaded sorting only implemented '
                                     'with Batcher\'s odd-even mergesort')
-            import sorting
+            from . import sorting
             sorting.radix_sort(self, self, n_bits=n_bits)
 
     def Array(self, size):
@@ -6346,7 +6346,7 @@ class SubMultiArray(_vectorizable):
         if key_indices is None:
             key_indices = (0,) * (len(self.sizes) - 1)
         key_indices = (None,) + util.tuplify(key_indices)
-        import sorting
+        from . import sorting
         keys = self.get_vector_by_indices(*key_indices)
         sorting.radix_sort(keys, self, n_bits=n_bits)
 

--- a/README.md
+++ b/README.md
@@ -466,21 +466,21 @@ for further examples.
 
 #### Compiling and running programs from external directories
 
-Programs can also be edited, compiled and run from any directory with the above basic structure. So for a source file in `./Programs/Source/`, all SPDZ scripts must be run from `./`. The `setup-online.sh` script must also be run from `./` to create the relevant data. For example:
+Programs can also be edited, compiled and run from any directory with the above basic structure. So for a source file in `./Programs/Source/`, all MP-SPDZ scripts must be run from `./`. The `setup-online.sh` script must also be run from `./` to create the relevant data. For example:
 
 ```
-spdz$ cd ../
+MP-SPDZ$ cd ../
 $ mkdir myprogs
 $ cd myprogs
 $ mkdir -p Programs/Source
 $ vi Programs/Source/test.mpc
-$ ../spdz/compile.py test.mpc
+$ ../MP-SPDZ/compile.py test.mpc
 $ ls Programs/
 Bytecode  Public-Input  Schedules  Source
-$ ../spdz/Scripts/setup-online.sh
+$ ../MP-SPDZ/Scripts/setup-online.sh
 $ ls
 Player-Data Programs
-$ ../spdz/Scripts/run-online.sh test
+$ ../MP-SPDZ/Scripts/run-online.sh test
 ```
 
 ### TensorFlow inference


### PR DESCRIPTION
When running `../MP-SPDZ/compile.py <progname>` from a neighboring directory, `sorting` does not import properly.

I also updated the README to reflect the current naming of this repository (rather than `spdz`.)