### PR TITLE
Add SqrtORAM 

### DIFF
--- a/Compiler/instructions.py
+++ b/Compiler/instructions.py
@@ -2501,6 +2501,26 @@ class delshuffle(base.Instruction):
     code = base.opcodes['DELSHUFFLE']
     arg_format = ['ci']
 
+class inverse_permutation(base.VectorInstruction, shuffle_base):
+    """ Calculate the inverse permutation of a secret permutation.
+
+    :param: destination (sint)
+    :param: source (sint)
+
+    """
+    __slots__ = []
+    code = base.opcodes['INVPERM']
+    arg_format = ['sw', 's']
+
+    def __init__(self, *args, **kwargs):
+        super(inverse_permutation, self).__init__(*args, **kwargs)
+        assert len(args[0]) == len(args[1])
+
+    def add_usage(self, req_node):
+        self.add_gen_usage(req_node, len(self.args[0]))
+        self.add_apply_usage(req_node, len(self.args[0]), 1)
+
+
 class check(base.Instruction):
     """
     Force MAC check in current thread and all idle thread if current

--- a/Compiler/instructions_base.py
+++ b/Compiler/instructions_base.py
@@ -111,6 +111,7 @@ opcodes = dict(
     GENSECSHUFFLE = 0xFB,
     APPLYSHUFFLE = 0xFC,
     DELSHUFFLE = 0xFD,
+    INVPERM = 0xFE,
     # Data access
     TRIPLE = 0x50,
     BIT = 0x51,

--- a/Compiler/sqrt_oram.py
+++ b/Compiler/sqrt_oram.py
@@ -3,10 +3,10 @@ from abc import abstractmethod
 import math
 from typing import Any, Generic, Type, TypeVar
 
-from Compiler.program import Program
 from Compiler import util
 from Compiler import library as lib
 from Compiler.GC.types import cbit, sbit, sbitint, sbits
+from Compiler.program import Program
 from Compiler.types import (
     Array,
     MemValue,
@@ -14,16 +14,28 @@ from Compiler.types import (
     _clear,
     _secret,
     cint,
+    regint,
     sint,
     sintbit,
-    regint
 )
+from oram import get_n_threads
 
 program = Program.prog
 
-debug = False
+debug = True
+trace = True
 n_threads = 8
-multithreading = True
+n_parallel = 1
+
+def get_n_threads(n_loops):
+    if n_threads is None:
+        if n_loops > 2048:
+            return 8
+        else:
+            return None
+    else:
+        return n_threads
+
 
 def swap(array: Array | MultiArray, pos_a: int | cint, pos_b: int | cint, cond: sintbit | sbit):
     """Swap two positions in an Array if a condition is met.
@@ -43,8 +55,10 @@ def swap(array: Array | MultiArray, pos_a: int | cint, pos_b: int | cint, cond: 
         array[pos_b] = cond.if_else(array[pos_a], array[pos_b])
         array[pos_a] = cond.if_else(temp, array[pos_a])
 
+
 T = TypeVar("T", sint, sbitint)
 B = TypeVar("B", sintbit, sbit)
+
 
 class SqrtOram(Generic[T, B]):
     # TODO: Preferably this is an Array of vectors, but this is currently not supported
@@ -75,7 +89,7 @@ class SqrtOram(Generic[T, B]):
         """Initialize a new Oblivious RAM using the "Square-Root" algorithm.
 
         Args:
-            data (MultiArray): The data with which to initialize the ORAM. For all intents and purposes, data is regarded as a one-dimensional Array. However, one may provide a MultiArray such that every "block" can hold multiple elements (an Array).
+            data (MultiArray): The data with which to initialize the ORAM. One may provide a MultiArray such that every "block" can hold multiple elements (an Array).
             value_type (sint): The secret type to use, defaults to sint.
             k (int): Leave at 0, this parameter is used to recursively pass down the depth of this ORAM.
             period (int): Leave at None, this parameter is used to recursively pass down the top-level period.
@@ -87,7 +101,8 @@ class SqrtOram(Generic[T, B]):
             self.n = math.ceil(len(data) // entry_length)
             if (len(data) % entry_length != 0):
                 raise Exception('Data incorrectly padded.')
-            self.shuffle = MultiArray((self.n, entry_length), value_type=value_type)
+            self.shuffle = MultiArray(
+                (self.n, entry_length), value_type=value_type)
             self.shuffle.assign_part_vector(data.get_vector())
         else:
             raise Exception("Incorrect format.")
@@ -96,19 +111,23 @@ class SqrtOram(Generic[T, B]):
         if value_type != sint and value_type != sbitint:
             raise Exception("The value_type must be either sint or sbitint")
         self.bit_type: Type[B] = value_type.bit_type
-        self.index_type = value_type.get_type(util.log2(self.n))
+        self.index_size = util.log2(self.n)
+        self.index_type = value_type.get_type(self.index_size)
         self.entry_length = entry_length
 
         if debug:
-            lib.print_ln('Initializing SqrtORAM of size %s at depth %s', self.n, k)
+            lib.print_ln(
+                'Initializing SqrtORAM of size %s at depth %s', self.n, k)
         self.shuffle_used = cint.Array(self.n)
         # Random permutation on the data
-        self.shufflei = Array.create_from([self.index_type(i) for i in range(self.n)])
+        self.shufflei = Array.create_from(
+            [self.index_type(i) for i in range(self.n)])
         permutation = Array.create_from(self.shuffle_the_shuffle())
         # Calculate the period if not given
         # upon recursion, the period should stay the same ("in sync"),
         # therefore it can be passed as a constructor parameter
-        self.T = int(math.ceil(math.sqrt(self.n * util.log2(self.n) - self.n + 1))) if not period else period
+        self.T = int(math.ceil(
+            math.sqrt(self.n * util.log2(self.n) - self.n + 1))) if not period else period
         if debug and not period:
             lib.print_ln('Period set to %s', self.T)
         # Initialize position map (recursive oram)
@@ -119,28 +138,108 @@ class SqrtOram(Generic[T, B]):
         self.stashi = Array(self.T, value_type=value_type)
         self.t = MemValue(cint(0))
 
-    @lib.method_block
-    def read(self, index: T):
-        value = self.value_type(0, size=self.entry_length)
-        return self.access(index, self.bit_type(False), *value)
-
-    @lib.method_block
-    def write(self, index: T, *value: T):
-        lib.runtime_error_if(len(value) != self.entry_length, "A block must be of size entry_length")
-        self.access(index, self.bit_type(True), *value)
-
-    __getitem__ = read
-    __setitem__ = write
+        # Initialize temp variables needed during the computation
+        self.found_ = self.bit_type.Array(size=self.T)
 
     @lib.method_block
     def access(self, index: T, write: B, *value: T):
-        if debug:
+        if trace:
             @lib.if_e(write.reveal() == 1)
             def _():
                 lib.print_ln('Writing to secret index %s', index.reveal())
+
             @lib.else_
             def __():
                 lib.print_ln('Reading from secret index %s', index.reveal())
+
+        value = self.value_type(value, size=self.entry_length).get_vector(0, size=self.entry_length)
+        index = MemValue(index)
+
+        # Refresh if we have performed T (period) accesses
+        @lib.if_(self.t == self.T)
+        def _():
+            self.refresh()
+
+        found: B = MemValue(self.bit_type(False))
+        result: T = MemValue(self.value_type(0, size=self.entry_length))
+
+        # First we scan the stash for the item
+        self.found_.assign_all(0)
+
+        # This will result in a bit array with at most one True,
+        # indicating where in the stash 'index' is found
+        @lib.multithread(get_n_threads(self.T), self.T)
+        def _(base, size):
+            self.found_.assign_vector(
+                    (self.stashi.get_vector(base, size) == index.expand_to_vector(size)) & \
+                            self.bit_type(regint.inc(size, base=base) < self.t.expand_to_vector(size)),
+                base=base)
+
+        # To determine whether the item is found in the stash, we simply
+        # check wheterh the demuxed array contains a True
+        # TODO: What if the index=0?
+        found.write(sum(self.found_))
+
+        # Store the stash item into the result if found
+        # If the item is not in the stash, the result will simple remain 0
+        @lib.map_sum(get_n_threads(self.T), n_parallel, self.T,
+                     self.entry_length, [self.value_type] * self.entry_length)
+        def stash_item(i):
+            entry = self.stash[i][:]
+            access_here = self.found_[i]
+            # This is a bit unfortunate
+            # We should loop from 0 to self.t, but t is dynamic thus this is impossible.
+            # Therefore we loop till self.T (the max value of self.t)
+            # is_in_time = i < self.t
+
+            # If we are writing, we need to add the value
+            self.stash[i] += write * access_here * (value - entry)
+            return (entry * access_here)[:]
+        result += self.value_type(stash_item(), size=self.entry_length)
+
+        if trace:
+            @lib.if_e(found.reveal() == 1)
+            def _():
+                lib.print_ln('\tFound item in stash')
+
+            @lib.else_
+            def __():
+                lib.print_ln('\tDid not find item in stash')
+
+        # Possible fake lookup of the item in the shuffle,
+        # depending on whether we already found the item in the stash
+        physical_address = self.position_map.get_position(index, found)
+        # We set shuffle_used to True, to track that this shuffle item needs to be refreshed
+        # with its equivalent on the stash once the period is up.
+        self.shuffle_used[physical_address] = cbit(True)
+
+        # If the item was not found in the stash
+        # ...we update the item in the shuffle
+        self.shuffle[physical_address] += write * found.bit_not() * (value - self.shuffle[physical_address][:])
+        # ...and the item retrieved from the shuffle is our result
+        result += self.shuffle[physical_address] * found.bit_not()
+        # We append the newly retrieved item to the stash
+        self.stash[self.t].assign(self.shuffle[physical_address][:])
+        self.stashi[self.t] = self.shufflei[physical_address]
+
+        if trace:
+            @lib.if_((write * found.bit_not()).reveal())
+            def _():
+                lib.print_ln('Wrote (%s: %s) to shuffle[%s]', self.stashi[self.t].reveal(), self.shuffle[physical_address].reveal(), physical_address)
+
+            lib.print_ln('\tAppended shuffle[%s]=(%s: %s) to stash at position t=%s', physical_address,
+                         self.shufflei[physical_address].reveal(), self.shuffle[physical_address].reveal(), self.t)
+
+        # Increase the "time" (i.e. access count in current period)
+        self.t.iadd(1)
+
+        return result
+
+    @lib.method_block
+    def write(self, index: T, *value: T):
+        if trace:
+            lib.print_ln('Writing to secret index %s', index.reveal())
+
         value = self.value_type(value)
         index = MemValue(index)
 
@@ -150,87 +249,159 @@ class SqrtOram(Generic[T, B]):
             self.refresh()
 
         found: B = MemValue(self.bit_type(False))
+        result: T = MemValue(self.value_type(0, size=self.entry_length))
 
-        # Scan through the stash
-        @lib.if_(self.t > 0)
-        def _():
-            nonlocal found
-            found |= index == self.stashi[0]
-        # We ensure that if the item is found in stash, it ends up in the first
-        # position (more importantly, a fixed position) of the stash
-        # This allows us to keep track of it in an oblivious manner
-        if multithreading:
-            found_ = self.bit_type.Array(size=self.T)
-            @lib.multithread(1, self.T)
-            def _(base, size):
-                found_.assign_vector((self.stashi.get_vector(base, size) == index.expand_to_vector(size))
-                        & self.bit_type(regint.inc(size, base=base) < self.t.expand_to_vector(size)),
-                        base=base)
-            @lib.for_range_opt(self.t - 1)
-            def _(i):
-                swap(self.stash, 0, i + 1, found_[i+1])
-                swap(self.stashi, 0, i + 1, found_[i+1])
-            found.write(sum(found_))
-        else:
-            @lib.for_range_opt(self.t - 1)
-            def _(i):
-                nonlocal found
-                found_: B =  index == self.stashi[i + 1]
-                swap(self.stash, 0, i + 1, found_)
-                swap(self.stashi, 0, i + 1, found_)
-                found |= found_
-        # If the item was not in the stash, we move the unknown and unimportant
-        # stash[0] out of the way (to the end of the stash)
-        swap(self.stash, self.t, 0, sintbit(found.bit_not().bit_and(self.t > 0)))
-        swap(self.stashi, self.t, 0, sintbit(found.bit_not().bit_and(self.t > 0)))
+        # First we scan the stash for the item
+        self.found_.assign_all(0)
 
-        if debug:
+        # This will result in an bit array with at most one True,
+        # indicating where in the stash 'index' is found
+        @lib.multithread(get_n_threads(self.T), self.T)
+        def _(base, size):
+            self.found_.assign_vector(
+                    (self.stashi.get_vector(base, size) == index.expand_to_vector(size)) & \
+                            self.bit_type(regint.inc(size, base=base) < self.t.expand_to_vector(size)),
+                base=base)
+
+        # To determine whether the item is found in the stash, we simply
+        # check wheterh the demuxed array contains a True
+        # TODO: What if the index=0?
+        found.write(sum(self.found_))
+
+        @lib.map_sum(get_n_threads(self.T), n_parallel, self.T,
+                     self.entry_length, [self.value_type] * self.entry_length)
+        def stash_item(i):
+            entry = self.stash[i][:]
+            access_here = self.found_[i]
+            # This is a bit unfortunate
+            # We should loop from 0 to self.t, but t is dynamic thus this is impossible.
+            # Therefore we loop till self.T (the max value of self.t)
+            # is_in_time = i < self.t
+
+            # We update the stash value
+            self.stash[i] += access_here * (value - entry)
+            return (entry * access_here)[:]
+        result += self.value_type(stash_item(), size=self.entry_length)
+
+        if trace:
             @lib.if_e(found.reveal() == 1)
             def _():
                 lib.print_ln('\tFound item in stash')
+
             @lib.else_
             def __():
-                lib.print_ln('\tItem not in stash')
-                lib.print_ln('\tMoved stash[0]=(%s: %s) to the back of the stash[t=%s]=(%s: %s)', self.stashi[0].reveal(), self.stash[0].reveal(), self.t, self.stashi[self.t].reveal(), self.stash[self.t].reveal())
+                lib.print_ln('\tDid not find item in stash')
 
         # Possible fake lookup of the item in the shuffle,
         # depending on whether we already found the item in the stash
         physical_address = self.position_map.get_position(index, found)
+        # We set shuffle_used to True, to track that this shuffle item needs to be refreshed
+        # with its equivalent on the stash once the period is up.
         self.shuffle_used[physical_address] = cbit(True)
 
-        # If the item was in the stash (thus currently residing in stash[0]),
-        # we place the random item retrieved from the shuffle at the end of the stash
-        self.stash[self.t].assign(found.if_else(
-            self.shuffle[physical_address][:],
-            self.stash[self.t][:]))
-        self.stashi[self.t] = found.if_else(
-                self.shufflei[physical_address],
-                self.stashi[self.t])
-        # If the item was not found in the stash, we place the item retrieved
-        # from the shuffle (the item we are actually looking for) in stash[0]
-        self.stash[0].assign(found.bit_not().if_else(
-            self.shuffle[physical_address][:],
-            self.stash[0][:]))
-        self.stashi[0] = found.bit_not().if_else(
-                self.shufflei[physical_address],
-                self.stashi[0])
+        # If the item was not found in the stash
+        # ...we update the item in the shuffle
+        self.shuffle[physical_address] += found.bit_not() * (value - self.shuffle[physical_address][:])
+        # ...and the item retrieved from the shuffle is our result
+        result += self.shuffle[physical_address] * found.bit_not()
+        # We append the newly retrieved item to the stash
+        self.stash[self.t].assign(self.shuffle[physical_address][:])
+        self.stashi[self.t] = self.shufflei[physical_address]
 
-        if debug:
-            @lib.if_e(found.reveal() == 1)
+        if trace:
+            @lib.if_(found.bit_not().reveal())
             def _():
-                lib.print_ln('\tMoved shuffle[%s]=(%s: %s) to stash[t]', physical_address, self.shufflei[physical_address].reveal(), self.shuffle[physical_address].reveal())
-            @lib.else_
-            def __():
-                lib.print_ln('\tMoved shuffle[%s]=(%s: %s) to stash[0]', physical_address, self.shufflei[physical_address].reveal(), self.shuffle[physical_address].reveal())
+                lib.print_ln('Wrote (%s: %s) to shuffle[%s]', self.stashi[self.t].reveal(), self.shuffle[physical_address].reveal(), physical_address)
 
+            lib.print_ln('\tAppended shuffle[%s]=(%s: %s) to stash at position t=%s', physical_address,
+                         self.shufflei[physical_address].reveal(), self.shuffle[physical_address].reveal(), self.t)
 
         # Increase the "time" (i.e. access count in current period)
         self.t.iadd(1)
 
-        self.stash[0].assign(write.if_else(value, self.stash[0][:]))
-        value=write.bit_not().if_else(self.stash[0][:], value)
-        return value
+        return result
 
+    @lib.method_block
+    def read(self, index: T, *value: T):
+        if trace:
+            lib.print_ln('Reading from secret index %s', index.reveal())
+        value = self.value_type(value)
+        index = MemValue(index)
+
+        # Refresh if we have performed T (period) accesses
+        @lib.if_(self.t == self.T)
+        def _():
+            self.refresh()
+
+        found: B = MemValue(self.bit_type(False))
+        result: T = MemValue(self.value_type(0, size=self.entry_length))
+
+        # First we scan the stash for the item
+        self.found_.assign_all(0)
+
+        # This will result in a bit array with at most one True,
+        # indicating where in the stash 'index' is found
+        @lib.multithread(get_n_threads(self.T), self.T)
+        def _(base, size):
+            self.found_.assign_vector(
+                    (self.stashi.get_vector(base, size) == index.expand_to_vector(size)) & \
+                            self.bit_type(regint.inc(size, base=base) < self.t.expand_to_vector(size)),
+                base=base)
+
+        # To determine whether the item is found in the stash, we simply
+        # check wheterh the demuxed array contains a True
+        # TODO: What if the index=0?
+        found.write(sum(self.found_))
+
+        # Store the stash item into the result if found
+        # If the item is not in the stash, the result will simple remain 0
+        @lib.map_sum(get_n_threads(self.T), n_parallel, self.T,
+                     self.entry_length, [self.value_type] * self.entry_length)
+        def stash_item(i):
+            entry = self.stash[i][:]
+            access_here = self.found_[i]
+            # This is a bit unfortunate
+            # We should loop from 0 to self.t, but t is dynamic thus this is impossible.
+            # Therefore we loop till self.T (the max value of self.t)
+            # is_in_time = i < self.t
+
+            return (entry * access_here)[:]
+        result += self.value_type(stash_item(), size=self.entry_length)
+
+        if trace:
+            @lib.if_e(found.reveal() == 1)
+            def _():
+                lib.print_ln('\tFound item in stash')
+
+            @lib.else_
+            def __():
+                lib.print_ln('\tDid not find item in stash')
+
+        # Possible fake lookup of the item in the shuffle,
+        # depending on whether we already found the item in the stash
+        physical_address = self.position_map.get_position(index, found)
+        # We set shuffle_used to True, to track that this shuffle item needs to be refreshed
+        # with its equivalent on the stash once the period is up.
+        self.shuffle_used[physical_address] = cbit(True)
+
+        # If the item was not found in the stash
+        # the item retrieved from the shuffle is our result
+        result += self.shuffle[physical_address] * found.bit_not()
+        # We append the newly retrieved item to the stash
+        self.stash[self.t].assign(self.shuffle[physical_address][:])
+        self.stashi[self.t] = self.shufflei[physical_address]
+
+        if trace:
+            lib.print_ln('\tAppended shuffle[%s]=(%s: %s) to stash at position t=%s', physical_address,
+                         self.shufflei[physical_address].reveal(), self.shuffle[physical_address].reveal(), self.t)
+
+        # Increase the "time" (i.e. access count in current period)
+        self.t.iadd(1)
+
+        return result
+
+    __getitem__ = read
+    __setitem__ = write
 
     @lib.method_block
     def shuffle_the_shuffle(self):
@@ -242,12 +413,15 @@ class SqrtOram(Generic[T, B]):
 
         # Random permutation on n elements
         random_shuffle = sint.get_secure_shuffle(self.n)
-        if debug: lib.print_ln('\tGenerated shuffle')
+        if trace:
+            lib.print_ln('\tGenerated shuffle')
         # Apply the random permutation
         self.shuffle.secure_permute(random_shuffle)
-        if debug: lib.print_ln('\tShuffled shuffle')
+        if trace:
+            lib.print_ln('\tShuffled shuffle')
         self.shufflei.secure_permute(random_shuffle)
-        if debug: lib.print_ln('\tShuffled shuffle indexes')
+        if trace:
+            lib.print_ln('\tShuffled shuffle indexes')
         # Calculate the permutation that would have produced the newly produced
         # shuffle order. This can be calculated by regarding the logical
         # indexes (shufflei) as a permutation and calculating its inverse,
@@ -256,7 +430,8 @@ class SqrtOram(Generic[T, B]):
         # random_shuffle, as the shuffle may already be out of order (e.g. when
         # refreshing).
         permutation = MemValue(self.shufflei[:].inverse_permutation())
-        if debug: lib.print_ln('\tCalculated inverse permutation')
+        if trace:
+            lib.print_ln('\tCalculated inverse permutation')
         return permutation
 
     @lib.method_block
@@ -266,10 +441,12 @@ class SqrtOram(Generic[T, B]):
 
         This must happen after T (period) accesses to the ORAM."""
 
-        if debug: lib.print_ln('Refreshing SqrtORAM')
+        if trace:
+            lib.print_ln('Refreshing SqrtORAM')
 
         # Shuffle and emtpy the stash, and store elements back into shuffle
-        j = MemValue(cint(0,size=1))
+        j = MemValue(cint(0, size=1))
+
         @lib.for_range_opt(self.n)
         def _(i):
             @lib.if_(self.shuffle_used[i])
@@ -301,13 +478,14 @@ class SqrtOram(Generic[T, B]):
         self.shufflei.assign([self.index_type(i) for i in range(self.n)])
         # Reset the clock
         self.t.write(0)
-        # Reset shuffle_used
+        # Reset shuffle_used 
         self.shuffle_used.assign_all(0)
 
         # Note that the self.shuffle is actually a MultiArray
         # This structure is preserved while overwriting the values using
         # assign_vector
-        self.shuffle.assign_vector(self.value_type(data, size=self.n * self.entry_length))
+        self.shuffle.assign_vector(self.value_type(
+            data, size=self.n * self.entry_length))
         permutation = self.shuffle_the_shuffle()
         self.position_map.reinitialize(*permutation)
 
@@ -316,13 +494,13 @@ class PositionMap(Generic[T, B]):
     PACK_LOG: int = 3
     PACK: int = 1 << PACK_LOG
 
-    n: int # n in the paper
-    depth: int # k in the paper
+    n: int  # n in the paper
+    depth: int  # k in the paper
     value_type: Type[T]
 
-    def __init__(self, n: int, value_type: Type[T] = sint, k:int = -1) -> None:
+    def __init__(self, n: int, value_type: Type[T] = sint, k: int = -1) -> None:
         self.n = n
-        self.depth=MemValue(cint(k))
+        self.depth = MemValue(cint(k))
         self.value_type = value_type
         self.bit_type = value_type.bit_type
         self.index_type = self.value_type.get_type(util.log2(n))
@@ -330,8 +508,9 @@ class PositionMap(Generic[T, B]):
     @abstractmethod
     def get_position(self, logical_address: _secret, fake: B) -> Any:
         """Retrieve the block at the given (secret) logical address."""
-        if debug:
-            lib.print_ln('\t%s Scanning %s for logical address %s (fake=%s)', self.depth, self.__class__.__name__, logical_address.reveal(), sintbit(fake).reveal())
+        if trace:
+            lib.print_ln('\t%s Scanning %s for logical address %s (fake=%s)', self.depth,
+                         self.__class__.__name__, logical_address.reveal(), sintbit(fake).reveal())
 
     def reinitialize(self, *permutation: T):
         """Reinitialize this PositionMap.
@@ -352,11 +531,13 @@ class PositionMap(Generic[T, B]):
 
         if n / PositionMap.PACK <= period:
             if debug:
-                lib.print_ln('Initializing LinearPositionMap at depth %s of size %s', k, n)
+                lib.print_ln(
+                    'Initializing LinearPositionMap at depth %s of size %s', k, n)
             res = LinearPositionMap(permutation, value_type, k=k)
         else:
             if debug:
-                lib.print_ln('Initializing RecursivePositionMap at depth %s of size %s', k, n)
+                lib.print_ln(
+                    'Initializing RecursivePositionMap at depth %s of size %s', k, n)
             res = RecursivePositionMap(permutation, period, value_type, k=k)
 
         return res
@@ -364,7 +545,7 @@ class PositionMap(Generic[T, B]):
 
 class RecursivePositionMap(PositionMap[T, B], SqrtOram[T, B]):
 
-    def __init__(self, permutation: Array, period: int, value_type: Type[T] = sint, k:int=-1) -> None:
+    def __init__(self, permutation: Array, period: int, value_type: Type[T] = sint, k: int = -1) -> None:
         PositionMap.__init__(self, len(permutation), k=k)
         pack = PositionMap.PACK
 
@@ -377,7 +558,8 @@ class RecursivePositionMap(PositionMap[T, B], SqrtOram[T, B]):
                 permutation[i*pack:(i+1)*pack])
 
         # TODO: Should this be n or packed_size?
-        SqrtOram.__init__(self, packed_structure, value_type=value_type, period=period, entry_length=pack, k=self.depth)
+        SqrtOram.__init__(self, packed_structure, value_type=value_type,
+                          period=period, entry_length=pack, k=self.depth)
 
     @lib.method_block
     def get_position(self, logical_address: T, fake: B) -> _clear:
@@ -389,7 +571,8 @@ class RecursivePositionMap(PositionMap[T, B], SqrtOram[T, B]):
         # The item at logical_address
         # will be in block with index h (block.<h>)
         # at position l in block.data (block.data<l>)
-        h = MemValue(self.value_type.bit_compose(sbits.get_type(program.bit_length)(logical_address).right_shift(pack_log, program.bit_length)))
+        h = MemValue(self.value_type.bit_compose(sbits.get_type(program.bit_length)(
+            logical_address).right_shift(pack_log, program.bit_length)))
         l = self.value_type.bit_compose(sbits(logical_address) & (pack - 1))
 
         # The resulting physical address
@@ -401,32 +584,37 @@ class RecursivePositionMap(PositionMap[T, B], SqrtOram[T, B]):
 
         # First we scan the stash for the block we need
         condition1 = self.bit_type.Array(self.T)
+
         @lib.for_range_opt_multithread(8, self.T)
         def _(i):
             condition1[i] = (self.stashi[i] == h) & self.bit_type(i < self.t)
         found = sum(condition1)
         # Once a block is found, we use condition2 to pick the correct item from that block
-        condition2 = Array.create_from(regint.inc(pack) == l.expand_to_vector(pack))
+        condition2 = Array.create_from(
+            regint.inc(pack) == l.expand_to_vector(pack))
         # condition3 combines condition1 & condition2, only returning true at stash[h][l]
         condition3 = self.bit_type.Array(self.T * pack)
+
         @lib.for_range_opt_multithread(8, [self.T, pack])
         def _(i, j):
             condition3[i*pack + j] = condition1[i] & condition2[j]
         # Finally we use condition3 to conditionally write p
+
         @lib.for_range(self.t)
         def _(i):
             @lib.for_range(pack)
             def _(j):
                 p.write(condition3[i*pack + j].if_else(self.stash[i][j], p))
 
-            if debug:
+            if trace:
                 @lib.if_(condition1[i].reveal() == 1)
                 def _():
-                    lib.print_ln('\t%s Found position in stash[%s]=(%s: %s)', self.depth, i, self.stashi[i].reveal(), self.stash[i].reveal())
+                    lib.print_ln('\t%s Found position in stash[%s]=(%s: %s)', self.depth, i, self.stashi[i].reveal(
+                    ), self.stash[i].reveal())
 
         # Then we try and retrieve the item from the shuffle (the actual memory)
 
-        if debug:
+        if trace:
             @lib.if_(found.reveal() == 0)
             def _():
                 lib.print_ln('\t%s Position not in stash', self.depth)
@@ -438,15 +626,16 @@ class RecursivePositionMap(PositionMap[T, B], SqrtOram[T, B]):
         # The block retrieved from the shuffle
         block_p_prime: Array = self.shuffle[p_prime]
 
-        if debug:
+        if trace:
             @lib.if_e(found.reveal() == 0)
             def _():
                 lib.print_ln('\t%s Retrieved stash[%s]=(%s: %s)',
-                        self.depth, p_prime.reveal(), self.shufflei[p_prime.reveal()].reveal(), self.shuffle[p_prime.reveal()].reveal())
+                             self.depth, p_prime.reveal(), self.shufflei[p_prime.reveal()].reveal(), self.shuffle[p_prime.reveal()].reveal())
+
             @lib.else_
             def __():
                 lib.print_ln('\t%s Retrieved dummy stash[%s]=(%s: %s)',
-                        self.depth, p_prime.reveal(), self.shufflei[p_prime.reveal()].reveal(), self.shuffle[p_prime.reveal()].reveal())
+                             self.depth, p_prime.reveal(), self.shufflei[p_prime.reveal()].reveal(), self.shuffle[p_prime.reveal()].reveal())
 
         # We add the retrieved block from the shuffle to the stash
         self.stash[self.t].assign(block_p_prime[:])
@@ -458,7 +647,9 @@ class RecursivePositionMap(PositionMap[T, B], SqrtOram[T, B]):
         condition: B = self.bit_type(fake.bit_or(found.bit_not()))
         # Retrieve l'th item from block
         # l is secret, so we must use linear scan
-        hit = Array.create_from((regint.inc(pack) == l.expand_to_vector(pack)) & condition.expand_to_vector(pack))
+        hit = Array.create_from((regint.inc(pack) == l.expand_to_vector(
+            pack)) & condition.expand_to_vector(pack))
+
         @lib.for_range_opt(pack)
         def _(i):
             p.write((hit[i]).if_else(block_p_prime[i], p))
@@ -469,14 +660,18 @@ class RecursivePositionMap(PositionMap[T, B], SqrtOram[T, B]):
     def reinitialize(self, *permutation: T):
         SqrtOram.reinitialize(self, *permutation)
 
+
 class LinearPositionMap(PositionMap):
     physical: Array
     used: Array
 
-    def __init__(self, data: Array, value_type: Type[T] = sint, k:int =-1) -> None:
+    def __init__(self, data: Array, value_type: Type[T] = sint, k: int = -1) -> None:
         PositionMap.__init__(self, len(data), value_type, k=k)
         self.physical = data
         self.used = self.bit_type.Array(self.n)
+
+        # Initialize random temp variables needed during the computation
+        self.physical_demux: Array = self.bit_type.Array(self.n)
 
     @lib.method_block
     def get_position(self, logical_address: T, fake: B) -> _clear:
@@ -484,52 +679,44 @@ class LinearPositionMap(PositionMap):
         This method corresponds to GetPosBase in the paper.
         """
         super().get_position(logical_address, fake)
+
         fake = MemValue(self.bit_type(fake))
         logical_address = MemValue(logical_address)
 
         p: MemValue = MemValue(self.index_type(-1))
         done: B = self.bit_type(False)
 
-        if multithreading:
-            conditions:Array = self.bit_type.Array(self.n)
-            conditions.assign_all(0)
+        # In order to get an address at secret logical_address,
+        # we need to perform a linear scan.
+        self.physical_demux.assign_all(0)
+        @lib.for_range_opt_multithread(8, self.n)
+        def condition_i(i):
+            self.physical_demux.assign((self.bit_type(fake).bit_not()
+                & self.bit_type(logical_address == i)) | (fake
+                    & self.used[i].bit_not()), base=i)
 
-            @lib.for_range_opt_multithread(8, self.n)
-            def condition_i(i):
-                conditions.assign((self.bit_type(fake).bit_not() & self.bit_type(logical_address == i)) | (fake & self.used[i].bit_not()), base=i)
+        # In the event that fake=True, there are likely multiple entried in physical_demux set to True (i.e. where self.used[i] = False)
+        # We only need once, so we pick the first one we find
+        @lib.for_range_opt(self.n)
+        def _(i):
+            nonlocal done
+            self.physical_demux[i] &= done.bit_not()
+            done |= self.physical_demux[i]
 
-            @lib.for_range_opt(self.n)
-            def _(i):
-                nonlocal done
-                conditions[i] &= done.bit_not()
-                done |= conditions[i]
-            @lib.map_sum_opt(8, self.n, [self.value_type])
-            def calc_p(i):
-                return self.physical[i] * conditions[i]
-            p.write(calc_p())
+        # Retrieve the value from the physical memory obliviously
+        @lib.map_sum_opt(8, self.n, [self.value_type])
+        def calc_p(i):
+            return self.physical[i] * self.physical_demux[i]
+        p.write(calc_p())
 
-            self.used.assign(self.used[:] | conditions[:])
-        else:
-            # In order to get an address at secret logical_address,
-            # we need to perform a linear scan.
-            linear_scan = self.bit_type.Array(self.n)
-            @lib.for_range_opt(self.n)
-            def _(i):
-                linear_scan[i] = logical_address == i
+        # Update self.used
+        self.used.assign(self.used[:] | self.physical_demux[:])
 
-            @lib.for_range_opt(self.n)
-            def __(j):
-                nonlocal done, fake
-                condition: B = (self.bit_type(fake.bit_not()) & linear_scan[j]) \
-                    .bit_or(fake & self.bit_type((self.used[j]).bit_not()) & done.bit_not())
-                p.write(condition.if_else(self.physical[j], p))
-                self.used[j] = condition.if_else(self.bit_type(True), self.used[j])
-                done = self.bit_type(condition.if_else(self.bit_type(True), done))
-
-        if debug:
+        if trace:
             @lib.if_((p.reveal() < 0).bit_or(p.reveal() > len(self.physical)))
             def _():
-                lib.runtime_error('%s Did not find requested logical_address in shuffle, something went wrong.', self.depth)
+                lib.runtime_error(
+                    '%s Did not find requested logical_address in shuffle, something went wrong.', self.depth)
 
         return p.reveal()
 

--- a/Compiler/sqrt_oram.py
+++ b/Compiler/sqrt_oram.py
@@ -1,0 +1,476 @@
+from __future__ import annotations
+from abc import abstractmethod
+from typing import Callable, Generic, Iterable, Literal, Type, Any, TypeVar
+from Compiler import library as lib
+from Compiler.GC.types import cbit, sbit, sbitint, sbits
+from Compiler.oram import AbstractORAM, get_n_threads
+from Compiler.types import MultiArray, sgf2n, sint, _secret, MemValue, Array, _clear, sintbit, cint
+import numpy as np
+
+debug = True
+reveal = True
+n_parallel = 1024
+
+def swap(array: Array | MultiArray, pos_a: int | cint, pos_b: int | cint, cond: sintbit | sbit):
+    if isinstance(array, MultiArray):
+        temp = array[pos_b][:]
+        array[pos_b].assign(cond.if_else(array[pos_a][:], array[pos_b][:]))
+        array[pos_a].assign(cond.if_else(temp, array[pos_a][:]))
+    if isinstance(array, Array):
+        temp = array[pos_b]
+        array[pos_b] = cond.if_else(array[pos_a], array[pos_b])
+        array[pos_a] = cond.if_else(temp, array[pos_a])
+
+T = TypeVar("T", sint, sbitint)
+B = TypeVar("B", sintbit, sbit)
+
+class SqrtOram(Generic[T, B]):
+    # TODO: Preferably this is an Array of vectors, but this is currently not supported
+    # One should regard these structures as Arrays where an entry may hold more
+    # than one value (which is a nice property to have when using the ORAM in
+    # practise).
+    shuffle: MultiArray
+    stash: MultiArray
+    # A block has an index and data
+    # `shuffle` and `stash` store the data,
+    # `shufflei` and `stashi` store the index
+    shufflei: Array
+    stashi: Array
+
+    shuffle_used: Array
+    position_map: PositionMap
+
+    # The size of the ORAM, i.e. how many elements it stores
+    n: int
+    # The period, i.e. how many calls can be made to the ORAM before it needs to be refreshed
+    T: int
+    # Keep track of how far we are in the period, and coincidentally how large
+    # the stash is (each access results in a fake or real block being put on
+    # the stash)
+    t: cint
+
+    def __init__(self, data: MultiArray, entry_length: int = 1, value_type: Type[T] = sint, k: int = 0, period: int | None = None) -> None:
+        """Initialize a new Oblivious RAM using the "Square-Root" algorithm.
+
+        Args:
+            data (MultiArray): The data with which to initialize the ORAM. For all intents and purposes, data is regarded as a one-dimensional Array. However, one may provide a MultiArray such that every "block" can hold multiple elements (an Array).
+            value_type (sint): The secret type to use, defaults to sint.
+            k (int): Leave at 0, this parameter is used to recursively pass down the depth of this ORAM.
+            period (int): Leave at None, this parameter is used to recursively pass down the top-level period.
+        """
+        self.n = len(data)
+
+        self.value_type = value_type
+        if value_type != sint and value_type != sbitint:
+            raise Exception("The value_type must be either sint or sbitint")
+        self.bit_type: Type[B] = value_type.bit_type
+        self.index_type = value_type.get_type(int(np.ceil(np.log2(self.n)) ))
+        self.entry_length = entry_length
+
+        if debug:
+            lib.print_ln('Initializing SqrtORAM of size %s at depth %s', self.n, k)
+        self.shuffle_used = cint.Array(self.n)
+        # Random permutation on the data
+        self.shuffle = data
+        self.shufflei = Array.create_from([self.index_type(i) for i in range(self.n)])
+        permutation = Array.create_from(self.shuffle_the_shuffle())
+        # Calculate the period if not given
+        # upon recursion, the period should stay the same ("in sync"),
+        # therefore it can be passed as a constructor parameter
+        self.T = int(np.ceil(np.sqrt(self.n * np.log2(self.n) - self.n + 1))
+                         ) if not period else period
+        if debug and not period:
+            lib.print_ln('Period set to %s', self.T)
+        # Initialize position map (recursive oram)
+        self.position_map = PositionMap.create(permutation, k + 1, self.T)
+
+        # Initialize stash
+        self.stash = MultiArray((self.T, data.sizes[1]), value_type=value_type)
+        self.stashi = Array(self.T, value_type=value_type)
+        self.t = MemValue(cint(0))
+
+
+    def read(self, index: T):
+        data = self.value_type.Array(self.entry_length)
+        return self.access(index, self.bit_type(False), data)
+
+    def write(self, index: T, value: Array):
+        self.access(index, self.bit_type(True), value)
+
+    __getitem__ = read
+    __setitem__ = write
+
+    def access(self, index: T, write: B, value: Array):
+        if len(value) != self.entry_length:
+            raise Exception("A block must be of size entry_length={}".format(self.entry_length))
+        # Method Blocks do not accepts arrays as arguments
+        # workaround by temporarily storing it as a class field
+        # arrays are stored in memory so this is fine
+        index = MemValue(index)
+        return Array.create_from(self._access(index, write, value[:]))
+
+    @lib.method_block
+    def _access(self, index: T, write: B, *value: list[T]):
+        item: T = self.value_type(*value)
+
+        if debug:
+            @lib.if_e(write.reveal() == 1)
+            def _():
+                lib.print_ln('Writing to secret index %s', index.reveal())
+            @lib.else_
+            def __():
+                lib.print_ln('Reading from secret index %s', index.reveal())
+
+        # Refresh if we have performed T (period) accesses
+        @lib.if_(self.t == self.T)
+        def _():
+            self.refresh()
+
+        found: B = MemValue(self.bit_type(False))
+
+        # Scan through the stash
+        @lib.if_(self.t > 0)
+        def _():
+            nonlocal found
+            found |= index == self.stashi[0]
+        # We ensure that if the item is found in stash, it ends up in the first
+        # position (more importantly, a fixed position) of the stash
+        # This allows us to keep track of it in an oblivious manner
+        @lib.for_range_opt(self.t)
+        def _(i):
+            nonlocal found
+            found_: B =  index == self.stashi[i + 1]
+            swap(self.stash, 0, i, found_)
+            swap(self.stashi, 0, i, found_)
+            found |= found_
+            #  found = self.bit_type(found.bit_or(found_))
+        # If the item was not in the stash, we move the unknown and unimportant
+        # stash[0] out of the way (to the end of the stash)
+        swap(self.stash, self.t, 0, sintbit(found.bit_not().bit_and(self.t > 0)))
+        swap(self.stashi, self.t, 0, sintbit(found.bit_not().bit_and(self.t > 0)))
+
+        if debug:
+            @lib.if_e(found.reveal() == 1)
+            def _():
+                lib.print_ln('    Found item in stash')
+            @lib.else_
+            def __():
+                lib.print_ln('    Item not in stash')
+                lib.print_ln('    Moved stash[0]=(%s: %s) to stash[t=%s]=(%s: %s)', self.stashi[0].reveal(), self.stash[0].reveal(), self.t, self.stashi[self.t].reveal(), self.stash[self.t].reveal())
+
+        # Possible fake lookup of the item in the shuffle,
+        # depending on whether we already found the item in the stash
+        physical_address = self.position_map.get_position(index, found)
+        self.shuffle_used[physical_address] = cbit(True)
+
+        # If the item was in the stash (thus currently residing in stash[0]),
+        # we place the random item retrieved from the shuffle at the end of the stash
+        self.stash[self.t].assign(found.if_else(
+            self.shuffle[physical_address][:],
+            self.stash[self.t][:]))
+        self.stashi[self.t] = found.if_else(
+                self.shufflei[physical_address],
+                self.stashi[self.t])
+        # If the item was not found in the stash,
+        # we place the item retrieved from the shuffle in stash[0]
+        self.stash[0].assign(found.bit_not().if_else(
+            self.shuffle[physical_address][:],
+            self.stash[0][:]))
+        self.stashi[0] = found.bit_not().if_else(
+                self.shufflei[physical_address],
+                self.stashi[0])
+        if debug:
+            @lib.if_e(found.reveal() == 1)
+            def _():
+                lib.print_ln('\tMoved shuffle[%s]=(%s: %s) to stash[t]', physical_address, self.shufflei[physical_address].reveal(), self.shuffle[physical_address].reveal())
+            @lib.else_
+            def __():
+                lib.print_ln('\tMoved shuffle[%s]=(%s: %s) to stash[0]', physical_address, self.shufflei[physical_address].reveal(), self.shuffle[physical_address].reveal())
+
+
+        # Increase the "time" (i.e. access count in current period)
+        self.t.iadd(1)
+
+        self.stash[0].assign(write.if_else(item, self.stash[0][:]))
+        item=write.bit_not().if_else(self.stash[0][:], item)
+        return item
+
+
+    @lib.method_block
+    def shuffle_the_shuffle(self):
+        """Permute the memory using a newly generated permutation and return
+        the permutation that would generate this particular shuffling.
+
+        This permutation is needed to know how to map logical addresses to
+        physical addresses, and is used as such by the postition map."""
+
+        # Random permutation on n elements
+        random_shuffle = sint.get_secure_shuffle(self.n)
+        # Apply the random permutation
+        lib.print_ln('\tGenerated shuffle')
+        self.shuffle.secure_permute(random_shuffle)
+        lib.print_ln('\tShuffled shuffle')
+        self.shufflei.secure_permute(random_shuffle)
+        lib.print_ln('\tShuffled shuffle indexes')
+        # Calculate the permutation that would have produced the newly produced
+        # shuffle order. This can be calculated by regarding the logical
+        # indexes (shufflei) as a permutation and calculating its inverse,
+        # i.e. find P such that P([1,2,3,...]) = shufflei.
+        # this is not necessarily equal to the inverse of the above generated
+        # random_shuffle, as the shuffle may already be out of order (e.g. when
+        # refreshing).
+        permutation = MemValue(self.shufflei[:].inverse_permutation())
+        lib.print_ln('\tCalculated inverse permutation')
+        return permutation
+
+    @lib.method_block
+    def refresh(self):
+        """Refresh the ORAM by reinserting the stash back into the shuffle, and
+        reshuffling the shuffle.
+
+        This must happen after T (period) accesses to the ORAM."""
+        lib.print_ln('Refreshing SqrtORAM')
+
+        # Shuffle and emtpy the stash, and store elements back into shuffle
+        j = MemValue(cint(0,size=1))
+        @lib.for_range_opt(self.n)
+        def _(i):
+            @lib.if_(self.shuffle_used[i])
+            def _():
+                nonlocal j
+                self.shuffle[i] = self.stash[j]
+                self.shufflei[i] = self.stashi[j]
+                j += 1
+
+        # Reset the clock
+        self.t.write(0)
+        # Reset shuffle_used
+        self.shuffle_used.assign_all(0)
+
+        # Reinitialize position map
+        permutation = self.shuffle_the_shuffle()
+        # Note that we skip here the step of "packing" the permutation.
+        # Since the underlying memory of the position map is already aligned in
+        # this packed structure, we can simply overwrite the memory while
+        # maintaining the structure.
+        self.position_map.reinitialize(*permutation)
+
+    @lib.method_block
+    def reinitialize(self, *data: T):
+        # Note that this method is only used during refresh, and as such is
+        # only called with a permutation as data.
+
+        # The logical addresses of some previous permutation are irrelevant and must be reset
+        self.shufflei.assign([self.index_type(i) for i in range(self.n)])
+        # Reset the clock
+        self.t.write(0)
+        # Reset shuffle_used
+        self.shuffle_used.assign_all(0)
+
+        # Note that the self.shuffle is actually a MultiArray
+        # This structure is preserved while overwriting the values using
+        # assign_vector
+        self.shuffle.assign_vector(self.value_type(data, size=self.n * self.entry_length))
+        permutation = self.shuffle_the_shuffle()
+        self.position_map.reinitialize(*permutation)
+
+
+class PositionMap(Generic[T, B]):
+    PACK_LOG: int = 2
+    PACK: int = 1 << PACK_LOG
+
+    n: int # n in the paper
+    depth: int # k in the paper
+    value_type: Type[T]
+
+    def __init__(self, n: int, value_type: Type[T] = sint, k:int = -1) -> None:
+        self.n = n
+        self.depth=MemValue(cint(k))
+        self.value_type = value_type
+        self.bit_type = value_type.bit_type
+        self.index_type = self.value_type.get_type(int(np.ceil(np.log2(n))))
+
+    @abstractmethod
+    def get_position(self, logical_address: _secret, fake: B) -> Any:
+        """Retrieve the block at the given (secret) logical address."""
+        if debug:
+            lib.print_ln('\t%s Scanning %s for logical address %s (fake=%s)', self.depth, self.__class__.__name__, logical_address.reveal(), sintbit(fake).reveal())
+
+    def reinitialize(self, *permutation: T):
+        """Reinitialize this PositionMap.
+
+        Since the reinitialization occurs at runtime (`on SqrtORAM.refresh()`),
+        we cannot simply call __init__ on self. Instead, we must take care to
+        reuse and overwrite the same memory.
+        """
+        ...
+
+    @classmethod
+    def create(cls, permutation: Array, k: int, period: int, value_type: Type[T] = sint) -> PositionMap:
+        """Creates a new PositionMap. This is the method one should call when
+        needing a new position map. Depending on the size of the given data, it
+        will either instantiate a RecursivePositionMap or
+        a LinearPositionMap."""
+        n = len(permutation)
+
+        if n / PositionMap.PACK <= period:
+            if debug:
+                lib.print_ln('Initializing LinearPositionMap at depth %s of size %s', k, n)
+            res = LinearPositionMap(permutation, value_type, k=k)
+        else:
+            if debug:
+                lib.print_ln('Initializing RecursivePositionMap at depth %s of size %s', k, n)
+            res = RecursivePositionMap(permutation, period, value_type, k=k)
+
+        return res
+
+
+class RecursivePositionMap(PositionMap[T, B], SqrtOram[T, B]):
+
+    def __init__(self, permutation: Array, period: int, value_type: Type[T] = sint, k:int=-1) -> None:
+        PositionMap.__init__(self, len(permutation), k=k)
+        pack = PositionMap.PACK
+
+        # We pack the permutation into a smaller structure, index with a new permutation
+        packed_size = int(np.ceil(self.n / pack))
+        packed_structure = MultiArray(
+            (packed_size, pack), value_type=value_type)
+        for i in range(packed_size):
+            packed_structure[i] = Array.create_from(
+                permutation[i*pack:(i+1)*pack])
+
+        # TODO: Should this be n or packed_size?
+        SqrtOram.__init__(self, packed_structure, value_type=value_type, period=period, entry_length=pack, k=self.depth)
+
+    @lib.method_block
+    def get_position(self, logical_address: T, fake: B) -> _clear:
+        super().get_position(logical_address, fake)
+
+        pack = PositionMap.PACK
+        pack_log = PositionMap.PACK_LOG
+
+        # The item at logical_address
+        # will be in block with index h (block.<h>)
+        # at position l in block.data (block.data<l>)
+        h = MemValue(self.value_type.bit_compose(sbits.get_type(program.bit_length)(logical_address).right_shift(pack_log, program.bit_length)))
+        l = self.value_type.bit_compose(sbits(logical_address) & (pack - 1))
+
+        # The resulting physical address
+        p = MemValue(self.index_type(0))
+        found: B = MemValue(self.bit_type(False))
+
+        # First we try and retrieve the item from the stash
+
+        # We retrieve stash[h]
+        # Since h is secret, we do this by scanning the entire stash
+        @lib.for_range(self.t)
+        def _(j):
+            nonlocal found
+            condition = self.stashi[j] == h
+            found |= condition
+            # block = stash[h]
+            # block is itself an array (it holds a permutation)
+            # we need to grab block[l]
+            @lib.for_range(pack)
+            def _(i):
+                nonlocal condition
+                condition &= l == i
+                p.write(condition.if_else(self.stash[j][i], p))
+
+            if debug:
+                @lib.if_(condition.reveal() == 1)
+                def _():
+                    lib.print_ln('\t%s Found position in stash[%s]=(%s: %s)', self.depth, j, self.stashi[j].reveal(), self.stash[j].reveal())
+
+        # Then we try and retrieve the item from the shuffle (the actual memory)
+
+        if debug:
+            @lib.if_(found.reveal() == 0)
+            def _():
+                lib.print_ln('\t%s Position not in stash', self.depth)
+
+
+        p_prime = self.position_map.get_position(h, found)
+        self.shuffle_used[p_prime] = cbit(True)
+        # The block retrieved from the shuffle
+        # Depending on whether the block has already been `found`, this block
+        # is either the desired block (found=False) or a random block
+        # (found=True)
+        block_p_prime: Array = self.shuffle[p_prime]
+
+        if debug:
+            @lib.if_e(found.reveal() == 0)
+            def _():
+                lib.print_ln('\t%s Retrieved stash[%s]=(%s: %s)', self.depth, p_prime.reveal(), self.shufflei[p_prime.reveal()].reveal(), self.shuffle[p_prime.reveal()].reveal())
+            @lib.else_
+            def __():
+                lib.print_ln('\t%s Retrieved dummy stash[%s]=(%s: %s)',self.depth, p_prime.reveal(), self.shufflei[p_prime.reveal()].reveal(), self.shuffle[p_prime.reveal()].reveal())
+
+        # We add the retrieved block from the shuffle to the stash
+        self.stash[self.t].assign(block_p_prime[:])
+        self.stashi[self.t] = self.shufflei[p_prime]
+        # Increase t
+        self.t += 1
+
+        # if found or not fake
+        condition = self.bit_type(fake.bit_or(found.bit_not()))
+        # Retrieve l'th item from block
+        # l is secret, so we must use linear scan
+        @lib.for_range_opt(pack)
+        def _(i):
+            hit: B = self.bit_type(i == l)
+            p.write((condition & hit).if_else(block_p_prime[i], p))
+
+        return p.reveal()
+
+    @lib.method_block
+    def reinitialize(self, *permutation: T):
+        SqrtOram.reinitialize(self, *permutation)
+
+class LinearPositionMap(PositionMap):
+    physical: Array
+    used: Array
+
+    def __init__(self, data: Array, value_type: Type[T] = sint, k:int =-1) -> None:
+        PositionMap.__init__(self, len(data), value_type, k=k)
+        self.physical = data
+        self.used = self.bit_type.Array(self.n)
+
+    @lib.method_block
+    def get_position(self, logical_address: T, fake: B) -> _clear:
+        """
+        This method corresponds to GetPosBase in the paper.
+        """
+        super().get_position(logical_address, fake)
+        fake = self.bit_type(fake)
+
+        # In order to get an address at secret logical_address,
+        # we need to perform a linear scan.
+        linear_scan = self.bit_type.Array(self.n)
+        @lib.for_range_opt(self.n)
+        def _(i):
+            linear_scan[i] = logical_address == i
+
+        p: MemValue = MemValue(self.index_type(-1))
+        done: B = self.bit_type(False)
+
+        @lib.for_range_opt(self.n)
+        def _(j):
+            nonlocal done, fake
+            condition: B = (self.bit_type(fake.bit_not()) & linear_scan[j]) \
+                .bit_or(fake & self.bit_type((self.used[j]).bit_not()) & done.bit_not())
+            p.write(condition.if_else(self.physical[j], p))
+            self.used[j] = condition.if_else(self.bit_type(True), self.used[j])
+            done = self.bit_type(condition.if_else(self.bit_type(True), done))
+
+        if debug:
+            @lib.if_((p.reveal() < 0).bit_or(p.reveal() > len(self.physical)))
+            def _():
+                lib.runtime_error('%s Did not find requested logical_address in shuffle, something went wrong.', self.depth)
+
+        return p.reveal()
+
+    @lib.method_block
+    def reinitialize(self, *data: T):
+        self.physical.assign_vector(data)
+        self.used.assign_all(False)

--- a/Compiler/types.py
+++ b/Compiler/types.py
@@ -2776,6 +2776,11 @@ class sint(_secret, _int):
         applyshuffle(res, self, unit_size, shuffle, reverse)
         return res
 
+    def inverse_permutation(self):
+        res = sint(size=self.size)
+        inverse_permutation(res, self)
+        return res
+
 class sintbit(sint):
     """ :py:class:`sint` holding a bit, supporting binary operations
     (``&, |, ^``). """

--- a/Compiler/types.py
+++ b/Compiler/types.py
@@ -6708,6 +6708,7 @@ class MemValue(_mem):
 
     if_else = lambda self,*args,**kwargs: self.read().if_else(*args, **kwargs)
     bit_and = lambda self,other: self.read().bit_and(other)
+    bit_not = lambda self: self.read().bit_not()
 
     def expand_to_vector(self, size=None):
         if program.curr_block == self.last_write_block:

--- a/Compiler/types.py
+++ b/Compiler/types.py
@@ -2777,8 +2777,20 @@ class sint(_secret, _int):
         return res
 
     def inverse_permutation(self):
-        res = sint(size=self.size)
-        inverse_permutation(res, self)
+        if program.use_invperm():
+            # If enabled, we use the low-level INVPERM instruction.
+            # This instruction has only been implemented for a semi-honest two-party environement.
+            res = sint(size=self.size)
+            inverse_permutation(res, self)
+        else:
+            shuffle = sint.get_secure_shuffle(len(self))
+            shuffled = self.secure_permute(shuffle).reveal()
+            idx = Array.create_from(shuffled)
+            res = Array.create_from(sint(regint.inc(len(self))))
+            res.secure_permute(shuffle, reverse=False)
+            res.assign_slice_vector(idx, res.get_vector())
+            library.break_point()
+            res = res.get_vector()
         return res
 
 class sintbit(sint):

--- a/Processor/Instruction.h
+++ b/Processor/Instruction.h
@@ -113,6 +113,7 @@ enum
     GENSECSHUFFLE = 0xFB,
     APPLYSHUFFLE = 0xFC,
     DELSHUFFLE = 0xFD,
+    INVPERM = 0xFE,
     // Data access
     TRIPLE = 0x50,
     BIT = 0x51,

--- a/Processor/Instruction.hpp
+++ b/Processor/Instruction.hpp
@@ -283,6 +283,10 @@ void BaseInstruction::parse_operands(istream& s, int pos, int file_pos)
         n = get_int(s);
         get_vector(2, start, s);
         break;
+      // instructions with 2 register operands
+      case INVPERM:
+          get_vector(2, start, s);
+          break;
       // open instructions + read/write instructions with variable length args
       case OPEN:
       case GOPEN:
@@ -1075,6 +1079,9 @@ inline void Instruction::execute(Processor<sint, sgf2n>& Proc) const
         return;
       case DELSHUFFLE:
         Proc.Procp.delete_shuffle(Proc.read_Ci(r[0]));
+        return;
+      case INVPERM:
+        Proc.Procp.inverse_permutation(*this);
         return;
       case CHECK:
         {

--- a/Processor/Processor.h
+++ b/Processor/Processor.h
@@ -77,6 +77,7 @@ public:
   size_t generate_secure_shuffle(const Instruction& instruction);
   void apply_shuffle(const Instruction& instruction, int handle);
   void delete_shuffle(int handle);
+  void inverse_permutation(const Instruction& instruction);
 
   void input_personal(const vector<int>& args);
   void send_personal(const vector<int>& args);
@@ -101,6 +102,8 @@ public:
   {
     return C[i];
   }
+
+    void inverse_permutation(const Instruction &instruction, int handle);
 };
 
 class ArithmeticProcessor : public ProcessorBase

--- a/Processor/Processor.hpp
+++ b/Processor/Processor.hpp
@@ -669,6 +669,12 @@ void SubProcessor<T>::delete_shuffle(int handle)
 }
 
 template<class T>
+void SubProcessor<T>::inverse_permutation(const Instruction& instruction) {
+    shuffler.inverse_permutation(S, instruction.get_size(), instruction.get_start()[0],
+                                 instruction.get_start()[1]);
+}
+
+template<class T>
 void SubProcessor<T>::input_personal(const vector<int>& args)
 {
   input.reset_all(P);
@@ -686,6 +692,16 @@ void SubProcessor<T>::input_personal(const vector<int>& args)
       S[args[i + 2] + j] = input.finalize(args[i + 1]);
 }
 
+/**
+ *
+ * @tparam T
+ * @param args Args contains four arguments
+ *      a[0] = the size of the input (and output) vector
+ *      a[1] = the player to which to reveal the output
+ *      a[2] = the memory address of the input vector (sint) (i.e. the value to reveal)
+ *      a[3] = the memory address of the output vector (cint) (i.e. the register to store the revealed value)
+ * // TODO: When would there be multiple sets of arguments? (for ... i < args.size(); i += 4 ... )
+ */
 template<class T>
 void SubProcessor<T>::private_output(const vector<int>& args)
 {

--- a/Protocols/SecureShuffle.h
+++ b/Protocols/SecureShuffle.h
@@ -24,8 +24,28 @@ class SecureShuffle
     size_t n_shuffle;
     bool exact;
 
+    /**
+     * Generates and returns a newly generated random permutation. This permutation is generated locally.
+     *
+     * @param n The size of the permutation to generate.
+     * @return A vector representing a permutation, a shuffled array of integers 0 through n-1.
+     */
+    vector<int> generate_random_permutation(int n);
+
+    /**
+     * Configure a shared waksman network from a permutation known only to config_player.
+     * Note that although the configuration bits of the waksman network are secret shared,
+     * the player that generated the permutation (config_player) knows the value of these bits.
+     *
+     * A permutation is a mapping represented as a vector.
+     * Each item in the vector represents the output of mapping(i) where i is the index of that item.
+     *      e.g. [2, 4, 0, 3, 1] -> perm(1) = 4
+     *
+     * @param config_player The player tasked with generating the random permutation from which to configure the waksman network.
+     * @param n_shuffle The size of the permutation to generate.
+     */
+    void configure(int config_player, vector<int>* perm, int n);
     void player_round(int config_player);
-    void generate(int config_player, int n_shuffle);
 
     void waksman(vector<T>& a, int depth, int start);
     void cond_swap(T& x, T& y, const T& b);
@@ -44,8 +64,36 @@ public:
 
     int generate(int n_shuffle);
 
+    /**
+     *
+     * @param a The vector of registers representing the stack // TODO: Is this correct?
+     * @param n The size of the input vector to shuffle
+     * @param unit_size Determines how many vector items constitute a single block with regards to permutation:
+     *                  i.e. input vector [1,2,3,4] with <code>unit_size=2</code> under permutation map [1,0]
+     *                  would result in [3,4,1,2]
+     * @param output_base The starting address of the output vector (i.e. the location to write the inverted permutation to)
+     * @param input_base The starting address of the input vector (i.e. the location from which to read the permutation)
+     * @param handle The integer identifying the preconfigured waksman network (shuffle) to use. Such a handle can be obtained from calling
+     * @param reverse Boolean indicating whether to apply the inverse of the permutation
+     * @see SecureShuffle::generate for obtaining a shuffle handle
+     */
     void apply(vector<T>& a, size_t n, int unit_size, size_t output_base,
             size_t input_base, int handle, bool reverse);
+
+    /**
+     * Calculate the secret inverse permutation of stack given secret permutation.
+     *
+     * This method is given in [1], based on stack technique in [2]. It is used in the Compiler (high-level) implementation of Square-Root ORAM.
+     *
+     * [1] Samee Zahur, Xiao Wang, Mariana Raykova, Adrià Gascón, Jack Doerner, David Evans, and Jonathan Katz. 2016. Revisiting Square Root ORAM: Efficient Random Access in Multi-Party Computation. In IEEE S&P.
+     * [2] Ivan Damgård, Matthias Fitzi, Eike Kiltz, Jesper Buus Nielsen, and Tomas Toft. Unconditionally Secure Constant-rounds Multi-Party Computation for Equality, Comparison, Bits and Exponentiation. In Theory of Cryptography, 2006.
+     *
+     * @param stack The vector or registers representing the stack (?)
+     * @param n The size of the input vector for which to calculate the inverse permutation
+     * @param output_base The starting address of the output vector (i.e. the location to write the inverted permutation to)
+     * @param input_base The starting address of the input vector (i.e. the location from which to read the permutation)
+     */
+    void inverse_permutation(vector<T>& stack, size_t n, size_t output_base, size_t input_base);
 
     void del(int handle);
 };

--- a/Protocols/SecureShuffle.hpp
+++ b/Protocols/SecureShuffle.hpp
@@ -58,6 +58,82 @@ void SecureShuffle<T>::apply(vector<T>& a, size_t n, int unit_size, size_t outpu
     post(a, n, output_base);
 }
 
+
+template<class T>
+void SecureShuffle<T>::inverse_permutation(vector<T> &stack, size_t n, size_t output_base,
+                                           size_t input_base) {
+    int alice = 0;
+    int bob = 1;
+
+    auto &P = proc.P;
+    auto &input = proc.input;
+
+    // This method only supports two players
+    assert(proc.protocol.get_relevant_players().size() == 2);
+    // The current implementation assumes a semi-honest environment
+    assert(!T::malicious);
+
+    // We are dealing directly with permutations, so the unit_size will always be 1.
+    this->unit_size = 1;
+    // We need to account for sizes which are not a power of 2
+    size_t n_pow2 = (1u << int(ceil(log2(n))));
+
+    // Copy over the input registers
+    pre(stack, n, input_base);
+    // Alice generates stack local permutation and shares the waksman configuration bits secretly to Bob.
+    vector<int> perm_alice(n_pow2);
+    if (P.my_num() == alice)
+        perm_alice = generate_random_permutation(n);
+    configure(alice, &perm_alice, n);
+    // Apply perm_alice to perm_alice to get perm_bob,
+    // stack permutation that we can reveal to Bob without Bob learning anything about perm_alice (since it is masked by perm_a)
+    iter_waksman(true);
+    // Store perm_bob at stack[output_base]
+    post(stack, n, output_base);
+
+    // Reveal permutation perm_bob = perm_a * perm_alice
+    // Since this permutation is masked by perm_a, Bob learns nothing about perm
+    vector<int> perm_bob(n_pow2);
+    typename T::PrivateOutput output(proc);
+    for (size_t i = 0; i < n; i++)
+        output.prepare_sending(stack[output_base + i], bob);
+    output.exchange();
+    for (size_t i = 0; i < n_pow2; i++) {
+        // TODO: Is there a better way to convert a T::clear to int?
+        bigint val;
+        output.finalize(bob).to(val);
+        perm_bob[i] = (int) val.get_si();
+    }
+
+    vector<int> perm_bob_inv(n_pow2);
+    if (P.my_num() == bob) {
+        for (int i = 0; i < (int) n; i++)
+            perm_bob_inv[perm_bob[i]] = i;
+        // Pad the permutation to n_pow2
+        // Required when using waksman networks
+        for (int i = (int) n; i < (int) n_pow2; i++)
+            perm_bob_inv[i] = i;
+    }
+
+    // Alice secret shares perm_a with bob
+    // perm_a is stored in the stack at output_base
+    input.reset_all(P);
+    if (P.my_num() == alice) {
+        for (int i = 0; i < (int) n; i++)
+            input.add_mine(perm_alice[i]);
+    }
+    input.exchange();
+    for (int i = 0; i < (int) n; i++)
+        stack[output_base + i] = input.finalize(alice);
+
+    // The two parties now jointly compute perm_a * perm_bob_inv to obtain perm_inv
+    pre(stack, n, output_base);
+    configure(bob, &perm_bob_inv, n);
+    iter_waksman(true);
+    // perm_inv is written back to stack[output_base]
+    post(stack, n, output_base);
+}
+
 template<class T>
 void SecureShuffle<T>::del(int handle)
 {
@@ -129,9 +205,27 @@ void SecureShuffle<T>::post(vector<T>& a, size_t n, size_t output_base)
 }
 
 template<class T>
-void SecureShuffle<T>::player_round(int config_player)
-{
-    generate(config_player, n_shuffle);
+vector<int> SecureShuffle<T>::generate_random_permutation(int n) {
+    vector<int> perm;
+    int n_pow2 = 1 << int(ceil(log2(n)));
+    int shuffle_size = n;
+    for (int j = 0; j < n_pow2; j++)
+        perm.push_back(j);
+    SeededPRNG G;
+    for (int i = 0; i < shuffle_size; i++) {
+        int j = G.get_uint(shuffle_size - i);
+        swap(perm[i], perm[i + j]);
+    }
+
+    return perm;
+}
+
+template<class T>
+void SecureShuffle<T>::player_round(int config_player) {
+    vector<int> random_perm(n_shuffle);
+    if (proc.P.my_num() == config_player)
+        random_perm = generate_random_permutation(n_shuffle);
+    configure(config_player, &random_perm, n_shuffle);
     iter_waksman();
 }
 
@@ -142,9 +236,12 @@ int SecureShuffle<T>::generate(int n_shuffle)
     shuffles.push_back({});
     auto& shuffle = shuffles.back();
 
-    for (auto i : proc.protocol.get_relevant_players())
-    {
-        generate(i, n_shuffle);
+    for (auto i: proc.protocol.get_relevant_players()) {
+        vector<int> perm;
+        if (proc.P.my_num() == i)
+            perm = generate_random_permutation(n_shuffle);
+        configure(i, &perm, n_shuffle);
+
         shuffle.push_back(config);
     }
 
@@ -152,39 +249,27 @@ int SecureShuffle<T>::generate(int n_shuffle)
 }
 
 template<class T>
-void SecureShuffle<T>::generate(int config_player, int n)
-{
-    auto& P = proc.P;
-    auto& input = proc.input;
+void SecureShuffle<T>::configure(int config_player, vector<int> *perm, int n) {
+    auto &P = proc.P;
+    auto &input = proc.input;
     input.reset_all(P);
     int n_pow2 = 1 << int(ceil(log2(n)));
     Waksman waksman(n_pow2);
 
-    if (P.my_num() == config_player)
-    {
-        vector<int> perm;
-        int shuffle_size = n;
-        for (int j = 0; j < n_pow2; j++)
-            perm.push_back(j);
-        SeededPRNG G;
-        for (int i = 0; i < shuffle_size; i++)
-        {
-            int j = G.get_uint(shuffle_size - i);
-            swap(perm[i], perm[i + j]);
-        }
-
-        auto config_bits = waksman.configure(perm);
-        for (size_t i = 0; i < config_bits.size(); i++)
-        {
-            auto& x = config_bits[i];
+    // The player specified by config_player configures the shared waksman network
+    // using its personal permutation
+    if (P.my_num() == config_player) {
+        auto config_bits = waksman.configure(*perm);
+        for (size_t i = 0; i < config_bits.size(); i++) {
+            auto &x = config_bits[i];
             for (size_t j = 0; j < x.size(); j++)
                 if (waksman.matters(i, j))
                     input.add_mine(int(x[j]));
                 else
                     assert(x[j] == 0);
         }
-    }
-    else
+        // The other player waits for its share of the configured waksman network
+    } else
         for (size_t i = 0; i < waksman.n_bits(); i++)
             input.add_other(config_player);
 

--- a/Protocols/SecureShuffle.hpp
+++ b/Protocols/SecureShuffle.hpp
@@ -98,7 +98,7 @@ void SecureShuffle<T>::inverse_permutation(vector<T> &stack, size_t n, size_t ou
     for (size_t i = 0; i < n; i++)
         output.prepare_sending(stack[output_base + i], bob);
     output.exchange();
-    for (size_t i = 0; i < n_pow2; i++) {
+    for (size_t i = 0; i < n; i++) {
         // TODO: Is there a better way to convert a T::clear to int?
         bigint val;
         output.finalize(bob).to(val);

--- a/compile.py
+++ b/compile.py
@@ -72,6 +72,8 @@ def main():
                       help="mixing arithmetic and binary computation")
     parser.add_option("-Y", "--edabit", action="store_true", dest="edabit",
                       help="mixing arithmetic and binary computation using edaBits")
+    parser.add_option("--invperm", action="store_true", dest="invperm",
+                      help="speedup inverse permutation (only use in two-party, semi-honest environment)")
     parser.add_option("-Z", "--split", default=defaults.split, dest="split",
                       help="mixing arithmetic and binary computation "
                       "using direct conversion if supported "


### PR DESCRIPTION
This PR adds the file `sqrt_oram.py` implementing the ORAM construction given in [1].
SqrtORAM promises:
- shorter access time than CircuitORAM for block amounts under 2**17
- initialize 100x faster than CircuitORAM

[1] Samee Zahur, Xiao Wang, Mariana Raykova, Adrià Gascón, Jack Doerner, David Evans, and Jonathan Katz. 2016. Revisiting Square Root ORAM: Efficient Random Access in Multi-Party Computation. In IEEE S&P.

NOTE: This pull-request depends on (and includes the commits of) #632 

===================

Although SqrtORAM is more or less a drop-in replacement for CircuitORAM, it does not extend AbstractORAM. The AbstractORAM seems to assume some functionality that SqrtORAM does not have, such as `evict()`.

Throughout the development I have tried to keep the code documented, so that hopefully others will be able to understand the code as well. The implementation closely mirrors the original Obliv-C implementation and the paper, so those should give a helpful guide as well.

Initial benchmarks seem to indicate that for smaller values of N (size of ORAM), SqrtORAM indeed has faster access times. 

| ORAM | N=10 | N=100 | N =1000 |
| --- | --- | --- | --- |
| SqrtORAM | 1.3406s | 17.5483s | 775.41s |
| RecursiveCircuitORAM | 7.89074s | 116.378s | 1570.09s |
| RecursivePathORAM | 5.25888s | 85.5535s | 1464.31s |

For each benchmark, the ORAM is intialized with N values equal to 0. The time taken during this initialization is not counted towards the time. Next, the oram is written to N times, and then read from N times. These 2*N accesses make up the time seen in the table.

