### PR TITLE
Provide more flexibility when compiling MPC programs

### DIFF
--- a/Compiler/__init__.py
+++ b/Compiler/__init__.py
@@ -2,30 +2,3 @@ from . import compilerLib, program, instructions, types, library, floatingpoint
 from .GC import types as GC_types
 import inspect
 from .config import *
-from .compilerLib import run
-
-
-# add all instructions to the program VARS dictionary
-compilerLib.VARS = {}
-instr_classes = [t[1] for t in inspect.getmembers(instructions, inspect.isclass)]
-
-for mod in (types, GC_types):
-    instr_classes += [t[1] for t in inspect.getmembers(mod, inspect.isclass)\
-                      if t[1].__module__ == mod.__name__]
-
-instr_classes += [t[1] for t in inspect.getmembers(library, inspect.isfunction)\
-    if t[1].__module__ == library.__name__]
-
-for op in instr_classes:
-    compilerLib.VARS[op.__name__] = op
-
-# add open and input separately due to name conflict
-compilerLib.VARS['open'] = instructions.asm_open
-compilerLib.VARS['vopen'] = instructions.vasm_open
-compilerLib.VARS['gopen'] = instructions.gasm_open
-compilerLib.VARS['vgopen'] = instructions.vgasm_open
-compilerLib.VARS['input'] = instructions.asm_input
-compilerLib.VARS['ginput'] = instructions.gasm_input
-
-compilerLib.VARS['comparison'] = comparison
-compilerLib.VARS['floatingpoint'] = floatingpoint

--- a/Compiler/compilerLib.py
+++ b/Compiler/compilerLib.py
@@ -279,7 +279,7 @@ class Compiler:
         parallelisable open instructions."""
         print("Compiling file", self.prog.infile)
 
-        with open(self.prog.infile, "rb") as f:
+        with open(self.prog.infile, "r") as f:
             changed = False
             if self.options.flow_optimization:
                 output = []

--- a/Compiler/compilerLib.py
+++ b/Compiler/compilerLib.py
@@ -367,7 +367,7 @@ class Compiler:
         print(
             f"Compiling: {self.compile_name} from " f"func {self.compile_func.__name__}"
         )
-        self.compile_function(self)
+        self.compile_function()
         self.finalize_compile()
 
     def finalize_compile(self):

--- a/Compiler/compilerLib.py
+++ b/Compiler/compilerLib.py
@@ -7,11 +7,15 @@ from optparse import OptionParser
 
 from .GC import types as GC_types
 from .program import Program, defaults
+from Compiler.exceptions import CompilerError
 
 
 class Compiler:
-    def __init__(self):
-        self.usage = "usage: %prog [options] filename [args]"
+    def __init__(self, usage=None):
+        if usage:
+            self.usage = usage
+        else:
+            self.usage = "usage: %prog [options] filename [args]"
         self.build_option_parser()
         self.VARS = {}
 
@@ -201,15 +205,11 @@ class Compiler:
 
     def parse_args(self):
         self.options, self.args = self.parser.parse_args()
-        if len(self.args) < 1:
-            self.parser.print_help()
-            return
-
         if self.options.optimize_hard:
             print("Note that -O/--optimize-hard currently has no effect")
 
-    def build_program(self):
-        self.prog = Program(self.args, self.options)
+    def build_program(self, name=None):
+        self.prog = Program(self.args, self.options, name=name)
 
     def build_vars(self):
         from . import comparison, floatingpoint, instructions, library, types
@@ -266,9 +266,9 @@ class Compiler:
             ]:
                 del self.VARS[i]
 
-    def prep_compile(self):
+    def prep_compile(self, name=None):
         self.parse_args()
-        self.build_program()
+        self.build_program(name=name)
         self.build_vars()
 
     def compile_file(self):
@@ -339,8 +339,8 @@ class Compiler:
 
         return self.finalize_compile()
 
-    def compile_func(self, f):
-        self.prep_compile()
+    def compile_func(self, f, name):
+        self.prep_compile(name)
         print(f"Compiling function: {f.__name__}")
         f(self.VARS)
         self.finalize_compile()

--- a/Compiler/compilerLib.py
+++ b/Compiler/compilerLib.py
@@ -1,94 +1,361 @@
-from Compiler.program import Program
-from .GC import types as GC_types
-
+import inspect
+import os
+import re
 import sys
-import re, tempfile, os
+import tempfile
+from optparse import OptionParser
+
+from .GC import types as GC_types
+from .program import Program, defaults
 
 
-def run(args, options):
-    """ Compile a file and output a Program object.
-    
-    If options.merge_opens is set to True, will attempt to merge any
-    parallelisable open instructions. """
-    
-    prog = Program(args, options)
-    VARS['program'] = prog
-    if options.binary:
-        VARS['sint'] = GC_types.sbitintvec.get_type(int(options.binary))
-        VARS['sfix'] = GC_types.sbitfixvec
-        for i in 'cint', 'cfix', 'cgf2n', 'sintbit', 'sgf2n', 'sgf2nint', \
-            'sgf2nuint', 'sgf2nuint32', 'sgf2nfloat', 'sfloat', 'cfloat', \
-            'squant':
-            del VARS[i]
-    
-    print('Compiling file', prog.infile)
-    f = open(prog.infile, 'rb')
+class Compiler:
+    def __init__(self):
+        self.usage = "usage: %prog [options] filename [args]"
+        self.build_option_parser()
+        self.VARS = {}
 
-    changed = False
-    if options.flow_optimization:
-        output = []
-        if_stack = []
-        for line in open(prog.infile):
-            if if_stack and not re.match(if_stack[-1][0], line):
-                if_stack.pop()
-            m = re.match(
-                '(\s*)for +([a-zA-Z_]+) +in +range\(([0-9a-zA-Z_]+)\):',
-                line)
-            if m:
-                output.append('%s@for_range_opt(%s)\n' % (m.group(1),
-                                                          m.group(3)))
-                output.append('%sdef _(%s):\n' % (m.group(1), m.group(2)))
-                changed = True
-                continue
-            m = re.match('(\s*)if(\W.*):', line)
-            if m:
-                if_stack.append((m.group(1), len(output)))
-                output.append('%s@if_(%s)\n' % (m.group(1), m.group(2)))
-                output.append('%sdef _():\n' % (m.group(1)))
-                changed = True
-                continue
-            m = re.match('(\s*)elif\s+', line)
-            if m:
-                raise CompilerError('elif not supported')
-            if if_stack:
-                m = re.match('%selse:' % if_stack[-1][0], line)
-                if m:
-                    start = if_stack[-1][1]
-                    ws = if_stack[-1][0]
-                    output[start] = re.sub(r'^%s@if_\(' % ws, r'%s@if_e(' % ws,
-                                           output[start])
-                    output.append('%s@else_\n' % ws)
-                    output.append('%sdef _():\n' % ws)
-                    continue
-            output.append(line)
-        if changed:
-            infile = tempfile.NamedTemporaryFile('w+', delete=False)
-            for line in output:
-                infile.write(line)
-            infile.seek(0)
-        else:
-            infile = open(prog.infile)
-    else:
-        infile = open(prog.infile)
+    def build_option_parser(self):
+        parser = OptionParser(usage=self.usage)
+        parser.add_option(
+            "-n",
+            "--nomerge",
+            action="store_false",
+            dest="merge_opens",
+            default=defaults.merge_opens,
+            help="don't attempt to merge open instructions",
+        )
+        parser.add_option("-o", "--output", dest="outfile", help="specify output file")
+        parser.add_option(
+            "-a",
+            "--asm-output",
+            dest="asmoutfile",
+            help="asm output file for debugging",
+        )
+        parser.add_option(
+            "-g",
+            "--galoissize",
+            dest="galois",
+            default=defaults.galois,
+            help="bit length of Galois field",
+        )
+        parser.add_option(
+            "-d",
+            "--debug",
+            action="store_true",
+            dest="debug",
+            help="keep track of trace for debugging",
+        )
+        parser.add_option(
+            "-c",
+            "--comparison",
+            dest="comparison",
+            default="log",
+            help="comparison variant: log|plain|inv|sinv",
+        )
+        parser.add_option(
+            "-M",
+            "--preserve-mem-order",
+            action="store_true",
+            dest="preserve_mem_order",
+            default=defaults.preserve_mem_order,
+            help="preserve order of memory instructions; possible efficiency loss",
+        )
+        parser.add_option(
+            "-O",
+            "--optimize-hard",
+            action="store_true",
+            dest="optimize_hard",
+            help="currently not in use",
+        )
+        parser.add_option(
+            "-u",
+            "--noreallocate",
+            action="store_true",
+            dest="noreallocate",
+            default=defaults.noreallocate,
+            help="don't reallocate",
+        )
+        parser.add_option(
+            "-m",
+            "--max-parallel-open",
+            dest="max_parallel_open",
+            default=defaults.max_parallel_open,
+            help="restrict number of parallel opens",
+        )
+        parser.add_option(
+            "-D",
+            "--dead-code-elimination",
+            action="store_true",
+            dest="dead_code_elimination",
+            default=defaults.dead_code_elimination,
+            help="eliminate instructions with unused result",
+        )
+        parser.add_option(
+            "-p",
+            "--profile",
+            action="store_true",
+            dest="profile",
+            help="profile compilation",
+        )
+        parser.add_option(
+            "-s",
+            "--stop",
+            action="store_true",
+            dest="stop",
+            help="stop on register errors",
+        )
+        parser.add_option(
+            "-R",
+            "--ring",
+            dest="ring",
+            default=defaults.ring,
+            help="bit length of ring (default: 0 for field)",
+        )
+        parser.add_option(
+            "-B",
+            "--binary",
+            dest="binary",
+            default=defaults.binary,
+            help="bit length of sint in binary circuit (default: 0 for arithmetic)",
+        )
+        parser.add_option(
+            "-F",
+            "--field",
+            dest="field",
+            default=defaults.field,
+            help="bit length of sint modulo prime (default: 64)",
+        )
+        parser.add_option(
+            "-P",
+            "--prime",
+            dest="prime",
+            default=defaults.prime,
+            help="prime modulus (default: not specified)",
+        )
+        parser.add_option(
+            "-I",
+            "--insecure",
+            action="store_true",
+            dest="insecure",
+            help="activate insecure functionality for benchmarking",
+        )
+        parser.add_option(
+            "-b",
+            "--budget",
+            dest="budget",
+            default=defaults.budget,
+            help="set budget for optimized loop unrolling " "(default: 100000)",
+        )
+        parser.add_option(
+            "-X",
+            "--mixed",
+            action="store_true",
+            dest="mixed",
+            help="mixing arithmetic and binary computation",
+        )
+        parser.add_option(
+            "-Y",
+            "--edabit",
+            action="store_true",
+            dest="edabit",
+            help="mixing arithmetic and binary computation using edaBits",
+        )
+        parser.add_option(
+            "-Z",
+            "--split",
+            default=defaults.split,
+            dest="split",
+            help="mixing arithmetic and binary computation "
+            "using direct conversion if supported "
+            "(number of parties as argument)",
+        )
+        parser.add_option(
+            "-C",
+            "--CISC",
+            action="store_true",
+            dest="cisc",
+            help="faster CISC compilation mode",
+        )
+        parser.add_option(
+            "-K",
+            "--keep-cisc",
+            dest="keep_cisc",
+            help="don't translate CISC instructions",
+        )
+        parser.add_option(
+            "-l",
+            "--flow-optimization",
+            action="store_true",
+            dest="flow_optimization",
+            help="optimize control flow",
+        )
+        parser.add_option(
+            "-v",
+            "--verbose",
+            action="store_true",
+            dest="verbose",
+            help="more verbose output",
+        )
+        self.parser = parser
 
-    # make compiler modules directly accessible
-    sys.path.insert(0, 'Compiler')
-    # create the tapes
-    exec(compile(infile.read(), infile.name, 'exec'), VARS)
+    def parse_args(self):
+        self.options, self.args = self.parser.parse_args()
+        if len(self.args) < 1:
+            self.parser.print_help()
+            return
 
-    if changed and not options.debug:
-        os.unlink(infile.name)
+        if self.options.optimize_hard:
+            print("Note that -O/--optimize-hard currently has no effect")
 
-    prog.finalize()
+    def build_program(self):
+        self.prog = Program(self.args, self.options)
 
-    if prog.req_num:
-        print('Program requires at most:')
-        for x in prog.req_num.pretty():
-            print(x)
+    def build_vars(self):
+        from . import comparison, floatingpoint, instructions, library, types
 
-    if prog.verbose:
-        print('Program requires:', repr(prog.req_num))
-        print('Cost:', 0 if prog.req_num is None else prog.req_num.cost())
-        print('Memory size:', dict(prog.allocated_mem))
+        # add all instructions to the program VARS dictionary
+        instr_classes = [
+            t[1] for t in inspect.getmembers(instructions, inspect.isclass)
+        ]
 
-    return prog
+        for mod in (types, GC_types):
+            instr_classes += [
+                t[1]
+                for t in inspect.getmembers(mod, inspect.isclass)
+                if t[1].__module__ == mod.__name__
+            ]
+
+        instr_classes += [
+            t[1]
+            for t in inspect.getmembers(library, inspect.isfunction)
+            if t[1].__module__ == library.__name__
+        ]
+
+        for op in instr_classes:
+            self.VARS[op.__name__] = op
+
+        # add open and input separately due to name conflict
+        self.VARS["open"] = instructions.asm_open
+        self.VARS["vopen"] = instructions.vasm_open
+        self.VARS["gopen"] = instructions.gasm_open
+        self.VARS["vgopen"] = instructions.vgasm_open
+        self.VARS["input"] = instructions.asm_input
+        self.VARS["ginput"] = instructions.gasm_input
+
+        self.VARS["comparison"] = comparison
+        self.VARS["floatingpoint"] = floatingpoint
+
+        self.VARS["program"] = self.prog
+        if self.options.binary:
+            self.VARS["sint"] = GC_types.sbitintvec.get_type(int(self.options.binary))
+            self.VARS["sfix"] = GC_types.sbitfixvec
+            for i in [
+                "cint",
+                "cfix",
+                "cgf2n",
+                "sintbit",
+                "sgf2n",
+                "sgf2nint",
+                "sgf2nuint",
+                "sgf2nuint32",
+                "sgf2nfloat",
+                "sfloat",
+                "cfloat",
+                "squant",
+            ]:
+                del self.VARS[i]
+
+    def prep_compile(self):
+        self.parse_args()
+        self.build_program()
+        self.build_vars()
+
+    def compile_file(self):
+        """Compile a file and output a Program object.
+
+        If options.merge_opens is set to True, will attempt to merge any
+        parallelisable open instructions."""
+        print("Compiling file", self.prog.infile)
+
+        with open(self.prog.infile, "rb") as f:
+            changed = False
+            if self.options.flow_optimization:
+                output = []
+                if_stack = []
+                for line in f:
+                    if if_stack and not re.match(if_stack[-1][0], line):
+                        if_stack.pop()
+                    m = re.match(
+                        r"(\s*)for +([a-zA-Z_]+) +in " r"+range\(([0-9a-zA-Z_]+)\):",
+                        line,
+                    )
+                    if m:
+                        output.append(
+                            "%s@for_range_opt(%s)\n" % (m.group(1), m.group(3))
+                        )
+                        output.append("%sdef _(%s):\n" % (m.group(1), m.group(2)))
+                        changed = True
+                        continue
+                    m = re.match(r"(\s*)if(\W.*):", line)
+                    if m:
+                        if_stack.append((m.group(1), len(output)))
+                        output.append("%s@if_(%s)\n" % (m.group(1), m.group(2)))
+                        output.append("%sdef _():\n" % (m.group(1)))
+                        changed = True
+                        continue
+                    m = re.match(r"(\s*)elif\s+", line)
+                    if m:
+                        raise CompilerError("elif not supported")
+                    if if_stack:
+                        m = re.match("%selse:" % if_stack[-1][0], line)
+                        if m:
+                            start = if_stack[-1][1]
+                            ws = if_stack[-1][0]
+                            output[start] = re.sub(
+                                r"^%s@if_\(" % ws, r"%s@if_e(" % ws, output[start]
+                            )
+                            output.append("%s@else_\n" % ws)
+                            output.append("%sdef _():\n" % ws)
+                            continue
+                    output.append(line)
+                if changed:
+                    infile = tempfile.NamedTemporaryFile("w+", delete=False)
+                    for line in output:
+                        infile.write(line)
+                    infile.seek(0)
+                else:
+                    infile = open(self.prog.infile)
+            else:
+                infile = open(self.prog.infile)
+
+        # make compiler modules directly accessible
+        sys.path.insert(0, "Compiler")
+        # create the tapes
+        exec(compile(infile.read(), infile.name, "exec"), self.VARS)
+
+        if changed and not self.options.debug:
+            os.unlink(infile.name)
+
+        return self.finalize_compile()
+
+    def compile_func(self, f):
+        self.prep_compile()
+        print(f"Compiling function: {f.__name__}")
+        f(self.VARS)
+        self.finalize_compile()
+
+    def finalize_compile(self):
+        self.prog.finalize()
+
+        if self.prog.req_num:
+            print("Program requires at most:")
+            for x in self.prog.req_num.pretty():
+                print(x)
+
+        if self.prog.verbose:
+            print("Program requires:", repr(self.prog.req_num))
+            print("Cost:", 0 if self.prog.req_num is None else self.prog.req_num.cost())
+            print("Memory size:", dict(self.prog.allocated_mem))
+
+        return self.prog

--- a/Compiler/compilerLib.py
+++ b/Compiler/compilerLib.py
@@ -12,11 +12,12 @@ from .program import Program, defaults
 
 
 class Compiler:
-    def __init__(self, usage=None):
+    def __init__(self, custom_args=None, usage=None):
         if usage:
             self.usage = usage
         else:
             self.usage = "usage: %prog [options] filename [args]"
+        self.custom_args = custom_args
         self.build_option_parser()
         self.VARS = {}
 
@@ -205,7 +206,7 @@ class Compiler:
         self.parser = parser
 
     def parse_args(self):
-        self.options, self.args = self.parser.parse_args()
+        self.options, self.args = self.parser.parse_args(self.custom_args)
         if self.options.optimize_hard:
             print("Note that -O/--optimize-hard currently has no effect")
 
@@ -358,7 +359,7 @@ class Compiler:
         return inner
 
     def compile_func(self):
-        if not hasattr(self, "compile_name") and hasattr(self, "compile_func"):
+        if not (hasattr(self, "compile_name") and hasattr(self, "compile_func")):
             raise CompilerError(
                 "No function to compile. "
                 "Did you decorate a function with @register_fuction(name)?"

--- a/Compiler/program.py
+++ b/Compiler/program.py
@@ -4,38 +4,39 @@ blocks and registers. Most relevant is the central :py:class:`Program`
 object that holds various properties of the computation.
 """
 
-from Compiler.config import *
-from Compiler.exceptions import *
-from Compiler.instructions_base import RegType
+import inspect
+import itertools
+import math
+import os
+import re
+import sys
+from collections import defaultdict, deque
+from functools import reduce
+
 import Compiler.instructions
 import Compiler.instructions_base
 import Compiler.instructions_base as inst_base
+from Compiler.config import REG_MAX, USER_MEM, COST
+from Compiler.exceptions import CompilerError
+from Compiler.instructions_base import RegType
+
 from . import allocator as al
 from . import util
-import random
-import time
-import sys, os, errno
-import inspect
-from collections import defaultdict, deque
-import itertools
-import math
-from functools import reduce
-import re
-
 
 data_types = dict(
-    triple = 0,
-    square = 1,
-    bit = 2,
-    inverse = 3,
-    dabit = 4,
+    triple=0,
+    square=1,
+    bit=2,
+    inverse=3,
+    dabit=4,
 )
 
 field_types = dict(
-    modp = 0,
-    gf2n = 1,
-    bit = 2,
+    modp=0,
+    gf2n=1,
+    bit=2,
 )
+
 
 class defaults:
     debug = False
@@ -62,8 +63,9 @@ class defaults:
     insecure = False
     keep_cisc = False
 
+
 class Program(object):
-    """ A program consists of a list of tapes representing the whole
+    """A program consists of a list of tapes representing the whole
     computation.
 
     When compiling an :file:`.mpc` file, the single instances is
@@ -71,20 +73,22 @@ class Program(object):
     from Python code, an instance has to be created before running any
     instructions.
     """
-    def __init__(self, args, options=defaults):
-        from .non_linear import Ring, Prime, KnownPrime
+
+    def __init__(self, args, options=defaults, name=None):
+        from .non_linear import KnownPrime, Prime
+
         self.options = options
         self.verbose = options.verbose
         self.args = args
+        self.name = name
         self.init_names(args)
         self._security = 40
         self.prime = None
         self.tapes = []
-        if sum(x != 0 for x in(options.ring, options.field,
-                                               options.binary)) > 1:
-            raise CompilerError('can only use one out of -B, -R, -F')
+        if sum(x != 0 for x in (options.ring, options.field, options.binary)) > 1:
+            raise CompilerError("can only use one out of -B, -R, -F")
         if options.prime and (options.ring or options.binary):
-            raise CompilerError('can only use one out of -B, -R, -p')
+            raise CompilerError("can only use one out of -B, -R, -p")
         if options.ring:
             self.set_ring_size(int(options.ring))
         else:
@@ -93,19 +97,20 @@ class Program(object):
                 self.prime = int(options.prime)
                 max_bit_length = int(options.prime).bit_length() - 2
                 if self.bit_length > max_bit_length:
-                    raise CompilerError('integer bit length can be maximal %s' %
-                                        max_bit_length)
+                    raise CompilerError(
+                        "integer bit length can be maximal %s" % max_bit_length
+                    )
                 self.bit_length = self.bit_length or max_bit_length
                 self.non_linear = KnownPrime(self.prime)
             else:
                 self.non_linear = Prime(self.security)
                 if not self.bit_length:
                     self.bit_length = 64
-        print('Default bit length:', self.bit_length)
-        print('Default security parameter:', self.security)
+        print("Default bit length:", self.bit_length)
+        print("Default security parameter:", self.security)
         self.galois_length = int(options.galois)
         if self.verbose:
-            print('Galois length:', self.galois_length)
+            print("Galois length:", self.galois_length)
         self.tape_counter = 0
         self._curr_tape = None
         self.DEBUG = options.debug
@@ -119,24 +124,36 @@ class Program(object):
         self.public_input_file = None
         self.types = {}
         self.budget = int(self.options.budget)
-        self.to_merge = [Compiler.instructions.asm_open_class, \
-                         Compiler.instructions.gasm_open_class, \
-                         Compiler.instructions.muls_class, \
-                         Compiler.instructions.gmuls_class, \
-                         Compiler.instructions.mulrs_class, \
-                         Compiler.instructions.gmulrs, \
-                         Compiler.instructions.dotprods_class, \
-                         Compiler.instructions.gdotprods_class, \
-                         Compiler.instructions.asm_input_class, \
-                         Compiler.instructions.gasm_input_class,
-                         Compiler.instructions.inputfix_class,
-                         Compiler.instructions.inputfloat_class,
-                         Compiler.instructions.inputmixed_class,
-                         Compiler.instructions.trunc_pr_class,
-                         Compiler.instructions_base.Mergeable]
+        self.to_merge = [
+            Compiler.instructions.asm_open_class,
+            Compiler.instructions.gasm_open_class,
+            Compiler.instructions.muls_class,
+            Compiler.instructions.gmuls_class,
+            Compiler.instructions.mulrs_class,
+            Compiler.instructions.gmulrs,
+            Compiler.instructions.dotprods_class,
+            Compiler.instructions.gdotprods_class,
+            Compiler.instructions.asm_input_class,
+            Compiler.instructions.gasm_input_class,
+            Compiler.instructions.inputfix_class,
+            Compiler.instructions.inputfloat_class,
+            Compiler.instructions.inputmixed_class,
+            Compiler.instructions.trunc_pr_class,
+            Compiler.instructions_base.Mergeable,
+        ]
         import Compiler.GC.instructions as gc
-        self.to_merge += [gc.ldmsdi, gc.stmsdi, gc.ldmsd, gc.stmsd, \
-                          gc.stmsdci, gc.xors, gc.andrs, gc.ands, gc.inputb]
+
+        self.to_merge += [
+            gc.ldmsdi,
+            gc.stmsdi,
+            gc.ldmsd,
+            gc.stmsd,
+            gc.stmsdci,
+            gc.xors,
+            gc.andrs,
+            gc.ands,
+            gc.inputb,
+        ]
         self.use_trunc_pr = False
         """ Setting whether to use special probabilistic truncation. """
         self.use_dabit = options.mixed
@@ -153,7 +170,8 @@ class Program(object):
         self.n_running_threads = None
         self.input_files = {}
         Program.prog = self
-        from . import instructions_base, instructions, types, comparison
+        from . import comparison, instructions, instructions_base, types
+
         instructions.program = self
         instructions_base.program = self
         types.program = self
@@ -164,53 +182,53 @@ class Program(object):
         return self.args
 
     def max_par_tapes(self):
-        """ Upper bound on number of tapes that will be run in parallel.
-        (Excludes empty tapes) """
+        """Upper bound on number of tapes that will be run in parallel.
+        (Excludes empty tapes)"""
         return self.n_threads
-    
+
     def init_names(self, args):
         # ignore path to file - source must be in Programs/Source
-        if 'Programs' in os.listdir(os.getcwd()):
+        if "Programs" in os.listdir(os.getcwd()):
             # compile prog in ./Programs/Source directory
-            self.programs_dir = os.getcwd() + '/Programs'
+            self.programs_dir = os.getcwd() + "/Programs"
         else:
             # assume source is in main SPDZ directory
-            self.programs_dir = sys.path[0] + '/Programs'
+            self.programs_dir = sys.path[0] + "/Programs"
         if self.verbose:
-            print('Compiling program in', self.programs_dir)
-        
+            print("Compiling program in", self.programs_dir)
+
         # create extra directories if needed
-        for dirname in ['Public-Input', 'Bytecode', 'Schedules']:
-            if not os.path.exists(self.programs_dir + '/' + dirname):
-                os.mkdir(self.programs_dir + '/' + dirname)
-        
-        progname = args[0].split('/')[-1]
-        if progname.endswith('.mpc'):
-            progname = progname[:-4]
-        
-        if os.path.exists(args[0]):
-            self.infile = args[0]
-        else:
-            self.infile = self.programs_dir + '/Source/' + progname + '.mpc'
+        for dirname in ["Public-Input", "Bytecode", "Schedules"]:
+            if not os.path.exists(self.programs_dir + "/" + dirname):
+                os.mkdir(self.programs_dir + "/" + dirname)
+
+        if self.name is None:
+            self.name = args[0].split("/")[-1]
+            if self.name.endswith(".mpc"):
+                self.name = self.name[:-4]
+
+            if os.path.exists(args[0]):
+                self.infile = args[0]
+            else:
+                self.infile = self.programs_dir + "/Source/" + self.name + ".mpc"
         """
         self.name is input file name (minus extension) + any optional arguments.
         Used to generate output filenames
         """
         if self.options.outfile:
-            self.name = self.options.outfile + '-' + progname
+            self.name = self.options.outfile + "-" + self.name
         else:
-            self.name = progname
+            self.name = self.name
         if len(args) > 1:
-            self.name += '-' + '-'.join(re.sub('/', '_', arg)
-                                        for arg in args[1:])
-        self.progname = progname
+            self.name += "-" + "-".join(re.sub("/", "_", arg) for arg in args[1:])
 
     def set_ring_size(self, ring_size):
         from .non_linear import Ring
+
         for tape in self.tapes:
-            prev = tape.req_bit_length['p']
+            prev = tape.req_bit_length["p"]
             if prev and prev != ring_size:
-                raise CompilerError('cannot have different ring sizes')
+                raise CompilerError("cannot have different ring sizes")
         self.bit_length = ring_size - 1
         self.non_linear = Ring(ring_size)
         self.options.ring = str(ring_size)
@@ -234,7 +252,8 @@ class Program(object):
         :param function: Python function defining the thread
         :param args: arguments to the function
         :param name: name used for files
-        :param single_thread: Boolean indicating whether tape will never be run in parallel to itself
+        :param single_thread: Boolean indicating whether tape will
+            never be run in parallel to itself
         :returns: tape handle
 
         """
@@ -258,20 +277,22 @@ class Program(object):
         return self.run_tapes([[tape_index, arg]])[0]
 
     def run_tapes(self, args):
-        """ Run tapes in parallel. See :py:func:`new_tape` for an example.
+        """Run tapes in parallel. See :py:func:`new_tape` for an example.
 
-        :param args: list of tape handles or tuples of tape handle and extra argument (for :py:func:`~Compiler.library.get_arg`)
+        :param args: list of tape handles or tuples of tape handle and extra
+            argument (for :py:func:`~Compiler.library.get_arg`)
         :returns: list of thread numbers
         """
         if not self.curr_tape.singular:
-            raise CompilerError('Compiler does not support ' \
-                                    'recursive spawning of threads')
+            raise CompilerError(
+                "Compiler does not support " "recursive spawning of threads"
+            )
         args = [list(util.tuplify(arg)) for arg in args]
         singular_tapes = set()
         for arg in args:
             if self.tapes[arg[0]].singular:
                 if arg[0] in singular_tapes:
-                    raise CompilerError('cannot run singular tape in parallel')
+                    raise CompilerError("cannot run singular tape in parallel")
                 singular_tapes.add(arg[0])
             assert len(arg)
             assert len(arg) <= 2
@@ -286,59 +307,59 @@ class Program(object):
             else:
                 thread_numbers.append(self.n_threads)
                 self.n_threads += 1
-        self.curr_tape.start_new_basicblock(name='pre-run_tape')
-        Compiler.instructions.run_tape(*sum(([x] + list(y) for x, y in
-                                             zip(thread_numbers, args)), []))
-        self.curr_tape.start_new_basicblock(name='post-run_tape')
+        self.curr_tape.start_new_basicblock(name="pre-run_tape")
+        Compiler.instructions.run_tape(
+            *sum(([x] + list(y) for x, y in zip(thread_numbers, args)), [])
+        )
+        self.curr_tape.start_new_basicblock(name="post-run_tape")
         for arg in args:
-            self.curr_tape.req_node.children.append(
-                self.tapes[arg[0]].req_tree)
+            self.curr_tape.req_node.children.append(self.tapes[arg[0]].req_tree)
         return thread_numbers
 
     def join_tape(self, thread_number):
         self.join_tapes([thread_number])
 
     def join_tapes(self, thread_numbers):
-        """ Wait for completion of tapes.  See :py:func:`new_tape` for an example.
+        """Wait for completion of tapes.  See :py:func:`new_tape` for an example.
 
         :param thread_numbers: list of thread numbers
         """
-        self.curr_tape.start_new_basicblock(name='pre-join_tape')
+        self.curr_tape.start_new_basicblock(name="pre-join_tape")
         for thread_number in thread_numbers:
             Compiler.instructions.join_tape(thread_number)
             self.curr_tape.free_threads.add(thread_number)
-        self.curr_tape.start_new_basicblock(name='post-join_tape')
+        self.curr_tape.start_new_basicblock(name="post-join_tape")
 
     def update_req(self, tape):
         if self.req_num is None:
             self.req_num = tape.req_num
         else:
             self.req_num += tape.req_num
-    
+
     def write_bytes(self):
 
-        """ Write all non-empty threads and schedule to files. """
+        """Write all non-empty threads and schedule to files."""
 
         nonempty_tapes = [t for t in self.tapes]
 
-        sch_filename = self.programs_dir + '/Schedules/%s.sch' % self.name
-        sch_file = open(sch_filename, 'w')
-        print('Writing to', sch_filename)
-        sch_file.write(str(self.max_par_tapes()) + '\n')
-        sch_file.write(str(len(nonempty_tapes)) + '\n')
-        sch_file.write(' '.join(tape.name for tape in nonempty_tapes) + '\n')
-        sch_file.write('1 0\n')
-        sch_file.write('0\n')
-        sch_file.write(' '.join(sys.argv) + '\n')
-        req = max(x.req_bit_length['p'] for x in self.tapes)
+        sch_filename = self.programs_dir + "/Schedules/%s.sch" % self.name
+        sch_file = open(sch_filename, "w")
+        print("Writing to", sch_filename)
+        sch_file.write(str(self.max_par_tapes()) + "\n")
+        sch_file.write(str(len(nonempty_tapes)) + "\n")
+        sch_file.write(" ".join(tape.name for tape in nonempty_tapes) + "\n")
+        sch_file.write("1 0\n")
+        sch_file.write("0\n")
+        sch_file.write(" ".join(sys.argv) + "\n")
+        req = max(x.req_bit_length["p"] for x in self.tapes)
         if self.options.ring:
-            sch_file.write('R:%s' % self.options.ring)
+            sch_file.write("R:%s" % self.options.ring)
         elif self.options.prime:
-            sch_file.write('p:%s' % self.options.prime)
+            sch_file.write("p:%s" % self.options.prime)
         else:
-            sch_file.write('lgp:%s' % req)
-        sch_file.write('\n')
-        sch_file.write('opts: %s\n' % ' '.join(self.relevant_opts))
+            sch_file.write("lgp:%s" % req)
+        sch_file.write("\n")
+        sch_file.write("opts: %s\n" % " ".join(self.relevant_opts))
         for tape in self.tapes:
             tape.write_bytes()
 
@@ -347,12 +368,12 @@ class Program(object):
             tape.optimize(self.options)
             tape.write_bytes()
             if self.options.asmoutfile:
-                tape.write_str(self.options.asmoutfile + '-' + tape.name)
+                tape.write_str(self.options.asmoutfile + "-" + tape.name)
             tape.purge()
-    
+
     @property
     def curr_tape(self):
-        """ The tape that is currently running."""
+        """The tape that is currently running."""
         if self._curr_tape is None:
             assert not self.tapes
             self._curr_tape = Tape(self.name, self)
@@ -365,13 +386,13 @@ class Program(object):
 
     @property
     def curr_block(self):
-        """ The basic block that is currently being created. """
+        """The basic block that is currently being created."""
         return self.curr_tape.active_basicblock
-    
+
     def malloc(self, size, mem_type, reg_type=None, creator_tape=None):
-        """ Allocate memory from the top """
+        """Allocate memory from the top"""
         if not isinstance(size, int):
-            raise CompilerError('size must be known at compile time')
+            raise CompilerError("size must be known at compile time")
         if size == 0:
             return
         if isinstance(mem_type, type):
@@ -389,8 +410,7 @@ class Program(object):
                 single_size = size
                 size *= self.n_running_threads
             else:
-                raise CompilerError('cannot allocate memory '
-                                    'outside main thread')
+                raise CompilerError("cannot allocate memory " "outside main thread")
         blocks = self.free_mem_blocks[mem_type]
         addr = blocks.pop(size)
         if addr is not None:
@@ -400,24 +420,23 @@ class Program(object):
             self.allocated_mem[mem_type] += size
             if len(str(addr)) != len(str(addr + size)) and self.verbose:
                 print("Memory of type '%s' now of size %d" % (mem_type, addr + size))
-            if addr + size >= 2 ** 32:
-                raise CompilerError("allocation exceeded for type '%s'" %
-                                    mem_type)
-        self.allocated_mem_blocks[addr,mem_type] = size
+            if addr + size >= 2**32:
+                raise CompilerError("allocation exceeded for type '%s'" % mem_type)
+        self.allocated_mem_blocks[addr, mem_type] = size
         if single_size:
             from .library import get_thread_number, runtime_error_if
+
             tn = get_thread_number()
-            runtime_error_if(tn > self.n_running_threads, 'malloc')
+            runtime_error_if(tn > self.n_running_threads, "malloc")
             return addr + single_size * (tn - 1)
         else:
             return addr
 
     def free(self, addr, mem_type):
-        """ Free memory """
-        if self.curr_block.alloc_pool \
-           is not self.curr_tape.basicblocks[0].alloc_pool:
-            raise CompilerError('Cannot free memory within function block')
-        size = self.allocated_mem_blocks.pop((addr,mem_type))
+        """Free memory"""
+        if self.curr_block.alloc_pool is not self.curr_tape.basicblocks[0].alloc_pool:
+            raise CompilerError("Cannot free memory within function block")
+        size = self.allocated_mem_blocks.pop((addr, mem_type))
         self.free_mem_blocks[mem_type].push(addr, size)
 
     def finalize(self):
@@ -435,47 +454,48 @@ class Program(object):
 
         if self.options.asmoutfile:
             for tape in self.tapes:
-                tape.write_str(self.options.asmoutfile + '-' + tape.name)
+                tape.write_str(self.options.asmoutfile + "-" + tape.name)
 
     def finalize_memory(self):
-        from . import library
-        self.curr_tape.start_new_basicblock(None, 'memory-usage')
+        self.curr_tape.start_new_basicblock(None, "memory-usage")
         # reset register counter to 0
         if not self.options.noreallocate:
             self.curr_tape.init_registers()
-        for mem_type,size in sorted(self.allocated_mem.items()):
+        for mem_type, size in sorted(self.allocated_mem.items()):
             if size:
-                #print "Memory of type '%s' of size %d" % (mem_type, size)
+                # print "Memory of type '%s' of size %d" % (mem_type, size)
                 if mem_type in self.types:
                     self.types[mem_type].load_mem(size - 1, mem_type)
                 else:
                     from Compiler.types import _get_type
+
                     _get_type(mem_type).load_mem(size - 1, mem_type)
         if self.verbose:
             if self.saved:
-                print('Saved %s memory units through reallocation' % self.saved)
+                print("Saved %s memory units through reallocation" % self.saved)
 
     def public_input(self, x):
-        """ Append a value to the public input file. """
+        """Append a value to the public input file."""
         if self.public_input_file is None:
-            self.public_input_file = open(self.programs_dir +
-                                          '/Public-Input/%s' % self.name, 'w')
-        self.public_input_file.write('%s\n' % str(x))
+            self.public_input_file = open(
+                self.programs_dir + "/Public-Input/%s" % self.name, "w"
+            )
+        self.public_input_file.write("%s\n" % str(x))
 
     def set_bit_length(self, bit_length):
-        """ Change the integer bit length for non-linear functions. """
+        """Change the integer bit length for non-linear functions."""
         self.bit_length = bit_length
-        print('Changed bit length for comparisons etc. to', bit_length)
+        print("Changed bit length for comparisons etc. to", bit_length)
 
     def set_security(self, security):
         self._security = security
         self.non_linear.set_security(security)
-        print('Changed statistical security for comparison etc. to', security)
+        print("Changed statistical security for comparison etc. to", security)
 
     @property
     def security(self):
-        """ The statistical security parameter for non-linear
-        functions. """
+        """The statistical security parameter for non-linear
+        functions."""
         return self._security
 
     @security.setter
@@ -493,7 +513,7 @@ class Program(object):
     @property
     def use_trunc_pr(self):
         if not self._use_trunc_pr:
-            self.relevant_opts.add('trunc_pr')
+            self.relevant_opts.add("trunc_pr")
         return self._use_trunc_pr
 
     @use_trunc_pr.setter
@@ -501,7 +521,7 @@ class Program(object):
         self._use_trunc_pr = change
 
     def use_edabit(self, change=None):
-        """ Setting whether to use edaBits for non-linear
+        """Setting whether to use edaBits for non-linear
         functionality (default: false).
 
         :param change: change setting if not :py:obj:`None`
@@ -509,7 +529,7 @@ class Program(object):
         """
         if change is None:
             if not self._edabit:
-                self.relevant_opts.add('edabit')
+                self.relevant_opts.add("edabit")
             return self._edabit
         else:
             self._edabit = change
@@ -518,7 +538,7 @@ class Program(object):
         return True
 
     def use_split(self, change=None):
-        """ Setting whether to use local arithmetic-binary share
+        """Setting whether to use local arithmetic-binary share
         conversion for non-linear functionality (default: false).
 
         :param change: change setting if not :py:obj:`None`
@@ -526,16 +546,16 @@ class Program(object):
         """
         if change is None:
             if not self._split:
-                self.relevant_opts.add('split')
+                self.relevant_opts.add("split")
             return self._split
         else:
             if change and not self.options.ring:
-                raise CompilerError('splitting only supported for rings')
-            assert change > 1 or change == False
+                raise CompilerError("splitting only supported for rings")
+            assert change > 1 or change is False
             self._split = change
 
     def use_square(self, change=None):
-        """ Setting whether to use preprocessed square tuples
+        """Setting whether to use preprocessed square tuples
         (default: false).
 
         :param change: change setting if not :py:obj:`None`
@@ -559,22 +579,22 @@ class Program(object):
             self._linear_rounds = change
 
     def options_from_args(self):
-        """ Set a number of options from the command-line arguments. """
-        if 'trunc_pr' in self.args:
+        """Set a number of options from the command-line arguments."""
+        if "trunc_pr" in self.args:
             self.use_trunc_pr = True
-        if 'signed_trunc_pr' in self.args:
+        if "signed_trunc_pr" in self.args:
             self.use_trunc_pr = -1
-        if 'split' in self.args or 'split3' in self.args:
+        if "split" in self.args or "split3" in self.args:
             self.use_split(3)
         for arg in self.args:
-            m = re.match('split([0-9]+)', arg)
+            m = re.match("split([0-9]+)", arg)
             if m:
                 self.use_split(int(m.group(1)))
-        if 'raw' in self.args:
+        if "raw" in self.args:
             self.always_raw(True)
-        if 'edabit' in self.args:
+        if "edabit" in self.args:
             self.use_edabit(True)
-        if 'linear_rounds' in self.args:
+        if "linear_rounds" in self.args:
             self.linear_rounds(True)
 
     def disable_memory_warnings(self):
@@ -583,28 +603,32 @@ class Program(object):
 
     @staticmethod
     def read_tapes(schedule):
-        m = re.search(r'([^/]*)\.mpc', schedule)
+        m = re.search(r"([^/]*)\.mpc", schedule)
         if m:
             schedule = m.group(1)
         if not os.path.exists(schedule):
-            schedule = 'Programs/Schedules/%s.sch' % schedule
+            schedule = "Programs/Schedules/%s.sch" % schedule
 
         try:
             lines = open(schedule).readlines()
         except FileNotFoundError:
-            print('%s not found, have you compiled the program?' % schedule,
-                  file=sys.stderr)
+            print(
+                "%s not found, have you compiled the program?" % schedule,
+                file=sys.stderr,
+            )
             sys.exit(1)
 
-        for tapename in lines[2].split(' '):
+        for tapename in lines[2].split(" "):
             yield tapename.strip()
 
+
 class Tape:
-    """ A tape contains a list of basic blocks, onto which instructions are added. """
+    """A tape contains a list of basic blocks, onto which instructions are added."""
+
     def __init__(self, name, program):
-        """ Set prime p and the initial instructions and registers. """
+        """Set prime p and the initial instructions and registers."""
         self.program = program
-        name += '-%d' % program.get_tape_counter()
+        name += "-%d" % program.get_tape_counter()
         self.init_names(name)
         self.init_registers()
         self.req_tree = self.ReqNode(name)
@@ -658,9 +682,9 @@ class Tape:
         def adjust_return(self):
             offset = self.sub_block.get_offset(self)
             self.previous_block.return_address_store.args[1] = offset
-        
+
         def set_exit(self, condition, exit_true=None):
-            """ Sets the block which we start from next, depending on the condition.
+            """Sets the block which we start from next, depending on the condition.
 
             (Default is to go to next block in the list)
             """
@@ -668,34 +692,33 @@ class Tape:
             self.exit_block = exit_true
             for reg in condition.get_used():
                 reg.can_eliminate = False
-        
+
         def add_jump(self):
-            """ Add the jump for this block's exit condition to list of
-            instructions (must be done after merging) """
+            """Add the jump for this block's exit condition to list of
+            instructions (must be done after merging)"""
             self.instructions.append(self.exit_condition)
-        
+
         def get_offset(self, next_block):
             return next_block.offset - (self.offset + len(self.instructions))
-        
+
         def adjust_jump(self):
-            """ Set the correct relative jump offset """
+            """Set the correct relative jump offset"""
             offset = self.get_offset(self.exit_block)
             self.exit_condition.set_relative_jump(offset)
-            #print 'Basic block %d jumps to %d (%d)' % (next_block_index, jump_index, offset)
 
         def purge(self, retain_usage=True):
             def relevant(inst):
-                req_node = Tape.ReqNode('')
+                req_node = Tape.ReqNode("")
                 req_node.num = Tape.ReqNum()
                 inst.add_usage(req_node)
                 return req_node.num != {}
+
             if retain_usage:
-                self.usage_instructions = list(filter(relevant,
-                                                      self.instructions))
+                self.usage_instructions = list(filter(relevant, self.instructions))
             else:
                 self.usage_instructions = []
             if len(self.usage_instructions) > 1000:
-                print('Retaining %d instructions' % len(self.usage_instructions))
+                print("Retaining %d instructions" % len(self.usage_instructions))
             del self.instructions
             self.purged = True
 
@@ -706,14 +729,14 @@ class Tape:
                 instructions = self.instructions
             for inst in instructions:
                 inst.add_usage(req_node)
-            req_node.num['all', 'round'] += self.n_rounds
-            req_node.num['all', 'inv'] += self.n_to_merge
+            req_node.num["all", "round"] += self.n_rounds
+            req_node.num["all", "inv"] += self.n_to_merge
 
         def expand_cisc(self):
             new_instructions = []
-            if self.parent.program.options.keep_cisc != None:
-                skip = ['LTZ', 'Trunc']
-                skip += self.parent.program.options.keep_cisc.split(',')
+            if self.parent.program.options.keep_cisc is not None:
+                skip = ["LTZ", "Trunc"]
+                skip += self.parent.program.options.keep_cisc.split(",")
             else:
                 skip = []
             for inst in self.instructions:
@@ -726,38 +749,38 @@ class Tape:
             return self.name
 
     def is_empty(self):
-        """ Returns True if the list of basic blocks is empty.
+        """Returns True if the list of basic blocks is empty.
 
         Note: False is returned even when tape only contains basic
         blocks with no instructions. However, these are removed when
-        optimize is called. """
+        optimize is called."""
         if not self.purged:
-            self._is_empty = (len(self.basicblocks) == 0)
+            self._is_empty = len(self.basicblocks) == 0
         return self._is_empty
 
-    def start_new_basicblock(self, scope=False, name=''):
+    def start_new_basicblock(self, scope=False, name=""):
         # use False because None means no scope
         if scope is False:
             scope = self.active_basicblock
-        suffix = '%s-%d' % (name, self.block_counter)
+        suffix = "%s-%d" % (name, self.block_counter)
         self.block_counter += 1
-        sub = self.BasicBlock(self, self.name + '-' + suffix, scope)
+        sub = self.BasicBlock(self, self.name + "-" + suffix, scope)
         self.basicblocks.append(sub)
         self.active_basicblock = sub
         self.req_node.add_block(sub)
-        #print 'Compiling basic block', sub.name
+        # print 'Compiling basic block', sub.name
 
     def init_registers(self):
         self.reg_counter = RegType.create_dict(lambda: 0)
-   
+
     def init_names(self, name):
         self.name = name
-        self.outfile = self.program.programs_dir + '/Bytecode/' + self.name + '.bc'
+        self.outfile = self.program.programs_dir + "/Bytecode/" + self.name + ".bc"
 
     def purge(self):
         for block in self.basicblocks:
             block.purge()
-        self._is_empty = (len(self.basicblocks) == 0)
+        self._is_empty = len(self.basicblocks) == 0
         del self.basicblocks
         del self.active_basicblock
         self.purged = True
@@ -767,26 +790,29 @@ class Tape:
             if self.purged:
                 return
             return function(self, *args, **kwargs)
+
         return wrapper
 
     @unpurged
     def optimize(self, options):
         if len(self.basicblocks) == 0:
-            print('Tape %s is empty' % self.name)
+            print("Tape %s is empty" % self.name)
             return
 
         if self.if_states:
-            print('Tracebacks for open blocks:')
+            print("Tracebacks for open blocks:")
             for state in self.if_states:
                 try:
                     print(util.format_trace(state.caller))
                 except AttributeError:
                     pass
             print()
-            raise CompilerError('Unclosed if/else blocks, see tracebacks above')
+            raise CompilerError("Unclosed if/else blocks, see tracebacks above")
 
         if self.program.verbose:
-            print('Processing tape', self.name, 'with %d blocks' % len(self.basicblocks))
+            print(
+                "Processing tape", self.name, "with %d blocks" % len(self.basicblocks)
+            )
 
         for block in self.basicblocks:
             al.determine_scope(block, options)
@@ -794,41 +820,56 @@ class Tape:
         # merge open instructions
         # need to do this if there are several blocks
         if (options.merge_opens and self.merge_opens) or options.dead_code_elimination:
-            for i,block in enumerate(self.basicblocks):
+            for i, block in enumerate(self.basicblocks):
                 if len(block.instructions) > 0 and self.program.verbose:
-                    print('Processing basic block %s, %d/%d, %d instructions' % \
-                        (block.name, i, len(self.basicblocks), \
-                         len(block.instructions)))
+                    print(
+                        "Processing basic block %s, %d/%d, %d instructions"
+                        % (
+                            block.name,
+                            i,
+                            len(self.basicblocks),
+                            len(block.instructions),
+                        )
+                    )
                 # the next call is necessary for allocation later even without merging
-                merger = al.Merger(block, options, \
-                                   tuple(self.program.to_merge))
+                merger = al.Merger(block, options, tuple(self.program.to_merge))
                 if options.dead_code_elimination:
                     if len(block.instructions) > 1000000:
-                        print('Eliminate dead code...')
+                        print("Eliminate dead code...")
                     merger.eliminate_dead_code()
                 if options.merge_opens and self.merge_opens:
                     if len(block.instructions) == 0:
                         block.used_from_scope = util.set_by_id()
                         continue
                     if len(block.instructions) > 1000000:
-                        print('Merging instructions...')
+                        print("Merging instructions...")
                     numrounds = merger.longest_paths_merge()
                     block.n_rounds = numrounds
                     block.n_to_merge = len(merger.open_nodes)
                     if merger.counter and self.program.verbose:
-                        print('Block requires', \
-                            ', '.join('%d %s' % (y, x.__name__) \
-                                     for x, y in list(merger.counter.items())))
+                        print(
+                            "Block requires",
+                            ", ".join(
+                                "%d %s" % (y, x.__name__)
+                                for x, y in list(merger.counter.items())
+                            ),
+                        )
                     if merger.counter and self.program.verbose:
-                        print('Block requires %s rounds' % \
-                            ', '.join('%d %s' % (y, x.__name__) \
-                                     for x, y in list(merger.rounds.items())))
+                        print(
+                            "Block requires %s rounds"
+                            % ", ".join(
+                                "%d %s" % (y, x.__name__)
+                                for x, y in list(merger.rounds.items())
+                            )
+                        )
                 # free memory
                 merger = None
                 if options.dead_code_elimination:
-                    block.instructions = [x for x in block.instructions if x is not None]
+                    block.instructions = [
+                        x for x in block.instructions if x is not None
+                    ]
         if not (options.merge_opens and self.merge_opens):
-            print('Not merging instructions in tape %s' % self.name)
+            print("Not merging instructions in tape %s" % self.name)
 
         if options.cisc:
             self.expand_cisc()
@@ -853,19 +894,27 @@ class Tape:
         reg_counts = self.count_regs()
         if options.noreallocate:
             if self.program.verbose:
-                print('Tape register usage:', dict(reg_counts))
+                print("Tape register usage:", dict(reg_counts))
         else:
             if self.program.verbose:
-                print('Tape register usage before re-allocation:',
-                      dict(reg_counts))
-                print('modp: %d clear, %d secret' % (reg_counts[RegType.ClearModp], reg_counts[RegType.SecretModp]))
-                print('GF2N: %d clear, %d secret' % (reg_counts[RegType.ClearGF2N], reg_counts[RegType.SecretGF2N]))
-                print('Re-allocating...')
+                print("Tape register usage before re-allocation:", dict(reg_counts))
+                print(
+                    "modp: %d clear, %d secret"
+                    % (reg_counts[RegType.ClearModp], reg_counts[RegType.SecretModp])
+                )
+                print(
+                    "GF2N: %d clear, %d secret"
+                    % (reg_counts[RegType.ClearGF2N], reg_counts[RegType.SecretGF2N])
+                )
+                print("Re-allocating...")
             allocator = al.StraightlineAllocator(REG_MAX, self.program)
+
             def alloc(block):
-                for reg in sorted(block.used_from_scope, 
-                                  key=lambda x: (x.reg_type, x.i)):
+                for reg in sorted(
+                    block.used_from_scope, key=lambda x: (x.reg_type, x.i)
+                ):
                     allocator.alloc_reg(reg, block.alloc_pool)
+
             def alloc_loop(block):
                 left = deque([block])
                 while left:
@@ -873,73 +922,84 @@ class Tape:
                     alloc(block)
                     for child in block.children:
                         left.append(child)
-            for i,block in enumerate(reversed(self.basicblocks)):
+
+            for i, block in enumerate(reversed(self.basicblocks)):
                 if len(block.instructions) > 1000000:
-                    print('Allocating %s, %d/%d' % \
-                        (block.name, i, len(self.basicblocks)))
+                    print(
+                        "Allocating %s, %d/%d" % (block.name, i, len(self.basicblocks))
+                    )
                 if block.exit_condition is not None:
                     jump = block.exit_condition.get_relative_jump()
-                    if isinstance(jump, int) and jump < 0 and \
-                            block.exit_block.scope is not None:
+                    if (
+                        isinstance(jump, int)
+                        and jump < 0
+                        and block.exit_block.scope is not None
+                    ):
                         alloc_loop(block.exit_block.scope)
                 allocator.process(block.instructions, block.alloc_pool)
             allocator.finalize(options)
             if self.program.verbose:
-                print('Tape register usage:', dict(allocator.usage))
+                print("Tape register usage:", dict(allocator.usage))
 
         # offline data requirements
         if self.program.verbose:
-            print('Compile offline data requirements...')
+            print("Compile offline data requirements...")
         self.req_num = self.req_tree.aggregate()
         if self.program.verbose:
-            print('Tape requires', self.req_num)
-        for req,num in sorted(self.req_num.items()):
-            if num == float('inf') or num >= 2 ** 32:
+            print("Tape requires", self.req_num)
+        for req, num in sorted(self.req_num.items()):
+            if num == float("inf") or num >= 2**32:
                 num = -1
             if req[1] in data_types:
                 self.basicblocks[-1].instructions.append(
-                    Compiler.instructions.use(field_types[req[0]], \
-                                                  data_types[req[1]], num, \
-                                                  add_to_prog=False))
-            elif req[1] == 'input':
+                    Compiler.instructions.use(
+                        field_types[req[0]], data_types[req[1]], num, add_to_prog=False
+                    )
+                )
+            elif req[1] == "input":
                 self.basicblocks[-1].instructions.append(
-                    Compiler.instructions.use_inp(field_types[req[0]], \
-                                                      req[2], num, \
-                                                      add_to_prog=False))
-            elif req[0] == 'modp':
+                    Compiler.instructions.use_inp(
+                        field_types[req[0]], req[2], num, add_to_prog=False
+                    )
+                )
+            elif req[0] == "modp":
                 self.basicblocks[-1].instructions.append(
-                    Compiler.instructions.use_prep(req[1], num, \
-                                                   add_to_prog=False))
-            elif req[0] == 'gf2n':
+                    Compiler.instructions.use_prep(req[1], num, add_to_prog=False)
+                )
+            elif req[0] == "gf2n":
                 self.basicblocks[-1].instructions.append(
-                    Compiler.instructions.guse_prep(req[1], num, \
-                                                    add_to_prog=False))
-            elif req[0] == 'edabit':
+                    Compiler.instructions.guse_prep(req[1], num, add_to_prog=False)
+                )
+            elif req[0] == "edabit":
                 self.basicblocks[-1].instructions.append(
-                    Compiler.instructions.use_edabit(False, req[1], num, \
-                                                     add_to_prog=False))
-            elif req[0] == 'sedabit':
+                    Compiler.instructions.use_edabit(
+                        False, req[1], num, add_to_prog=False
+                    )
+                )
+            elif req[0] == "sedabit":
                 self.basicblocks[-1].instructions.append(
-                    Compiler.instructions.use_edabit(True, req[1], num, \
-                                                     add_to_prog=False))
-            elif req[0] == 'matmul':
+                    Compiler.instructions.use_edabit(
+                        True, req[1], num, add_to_prog=False
+                    )
+                )
+            elif req[0] == "matmul":
                 self.basicblocks[-1].instructions.append(
-                    Compiler.instructions.use_matmul(*req[1], num, \
-                                                     add_to_prog=False))
+                    Compiler.instructions.use_matmul(*req[1], num, add_to_prog=False)
+                )
 
         if not self.is_empty():
             # bit length requirement
-            for x in ('p', '2'):
+            for x in ("p", "2"):
                 if self.req_bit_length[x]:
                     bl = self.req_bit_length[x]
                     if self.program.options.ring:
                         bl = -int(self.program.options.ring)
                     self.basicblocks[-1].instructions.append(
-                        Compiler.instructions.reqbl(bl,
-                                                    add_to_prog=False))
+                        Compiler.instructions.reqbl(bl, add_to_prog=False)
+                    )
             if self.program.verbose:
-                print('Tape requires prime bit length', self.req_bit_length['p'])
-                print('Tape requires galois bit length', self.req_bit_length['2'])
+                print("Tape requires prime bit length", self.req_bit_length["p"])
+                print("Tape requires galois bit length", self.req_bit_length["2"])
 
     @unpurged
     def expand_cisc(self):
@@ -948,93 +1008,99 @@ class Tape:
 
     @unpurged
     def _get_instructions(self):
-        return itertools.chain.\
-            from_iterable(b.instructions for b in self.basicblocks)
+        return itertools.chain.from_iterable(b.instructions for b in self.basicblocks)
 
     @unpurged
     def get_encoding(self):
-        """ Get the encoding of the program, in human-readable format. """
+        """Get the encoding of the program, in human-readable format."""
         return [i.get_encoding() for i in self._get_instructions() if i is not None]
-    
+
     @unpurged
     def get_bytes(self):
-        """ Get the byte encoding of the program as an actual string of bytes. """
-        return b"".join(i.get_bytes() for i in self._get_instructions() if i is not None)
-    
+        """Get the byte encoding of the program as an actual string of bytes."""
+        return b"".join(
+            i.get_bytes() for i in self._get_instructions() if i is not None
+        )
+
     @unpurged
     def write_encoding(self, filename):
-        """ Write the readable encoding to a file. """
-        print('Writing to', filename)
-        f = open(filename, 'w')
+        """Write the readable encoding to a file."""
+        print("Writing to", filename)
+        f = open(filename, "w")
         for line in self.get_encoding():
-            f.write(str(line) + '\n')
+            f.write(str(line) + "\n")
         f.close()
-    
+
     @unpurged
     def write_str(self, filename):
-        """ Write the sequence of instructions to a file. """
-        print('Writing to', filename)
-        f = open(filename, 'w')
+        """Write the sequence of instructions to a file."""
+        print("Writing to", filename)
+        f = open(filename, "w")
         n = 0
         for block in self.basicblocks:
             if block.instructions:
-                f.write('# %s\n' % block.name)
+                f.write("# %s\n" % block.name)
                 for line in block.instructions:
-                    f.write('%s # %d\n' % (line, n))
+                    f.write("%s # %d\n" % (line, n))
                     n += 1
         f.close()
-    
+
     @unpurged
     def write_bytes(self, filename=None):
-        """ Write the program's byte encoding to a file. """
+        """Write the program's byte encoding to a file."""
         if filename is None:
             filename = self.outfile
-        if not filename.endswith('.bc'):
-            filename += '.bc'
-        if not 'Bytecode' in filename:
-            filename = self.program.programs_dir + '/Bytecode/' + filename
-        print('Writing to', filename)
-        f = open(filename, 'wb')
+        if not filename.endswith(".bc"):
+            filename += ".bc"
+        if "Bytecode" not in filename:
+            filename = self.program.programs_dir + "/Bytecode/" + filename
+        print("Writing to", filename)
+        f = open(filename, "wb")
         for i in self._get_instructions():
             if i is not None:
                 f.write(i.get_bytes())
         f.close()
-    
+
     def new_reg(self, reg_type, size=None):
         return self.Register(reg_type, self, size=size)
-    
+
     def count_regs(self, reg_type=None):
         if reg_type is None:
             return self.reg_counter
         else:
             return self.reg_counter[reg_type]
-    
+
     def __str__(self):
         return self.name
 
     class ReqNum(defaultdict):
         def __init__(self, init={}):
             super(Tape.ReqNum, self).__init__(lambda: 0, init)
+
         def __add__(self, other):
             res = Tape.ReqNum()
-            for i,count in list(self.items()):
-                res[i] += count            
-            for i,count in list(other.items()):
+            for i, count in list(self.items()):
+                res[i] += count
+            for i, count in list(other.items()):
                 res[i] += count
             return res
+
         def __mul__(self, other):
             res = Tape.ReqNum()
             for i in self:
                 res[i] = other * self[i]
             return res
+
         __rmul__ = __mul__
+
         def set_all(self, value):
-            if value == float('inf') and self['all', 'inv'] > 0:
-                print('Going to unknown from %s' % self)
+            if value == float("inf") and self["all", "inv"] > 0:
+                print("Going to unknown from %s" % self)
             res = Tape.ReqNum()
             for i in self:
                 res[i] = value
             return res
+
         def max(self, other):
             res = Tape.ReqNum()
             for i in self:
@@ -1042,82 +1108,103 @@ class Tape:
             for i in other:
                 res[i] = max(self[i], other[i])
             return res
+
         def cost(self):
-            return sum(num * COST[req[0]][req[1]] for req,num in list(self.items()) \
-                       if req[1] != 'input' and req[0] != 'edabit')
+            return sum(
+                num * COST[req[0]][req[1]]
+                for req, num in list(self.items())
+                if req[1] != "input" and req[0] != "edabit"
+            )
+
         def pretty(self):
-            t = lambda x: 'integer' if x == 'modp' else x
+            def t(x):
+                return "integer" if x == "modp" else x
+
             res = []
             for req, num in self.items():
                 domain = t(req[0])
-                n = '%12.0f' % num
-                if req[1] == 'input':
-                    res += ['%s %s inputs from player %d' \
-                            % (n, domain, req[2])]
-                elif domain.endswith('edabit'):
-                    if domain == 'sedabit':
-                        eda = 'strict edabits'
+                n = "%12.0f" % num
+                if req[1] == "input":
+                    res += ["%s %s inputs from player %d" % (n, domain, req[2])]
+                elif domain.endswith("edabit"):
+                    if domain == "sedabit":
+                        eda = "strict edabits"
                     else:
-                        eda = 'loose edabits'
-                    res += ['%s %s of length %d' % (n, eda, req[1])]
-                elif domain == 'matmul':
-                    res += ['%s matrix multiplications (%dx%d * %dx%d)' %
-                            (n, req[1][0], req[1][1], req[1][1], req[1][2])]
-                elif req[0] != 'all':
-                    res += ['%s %s %ss' % (n, domain, req[1])]
-            if self['all','round']:
-                res += ['% 12.0f virtual machine rounds' % self['all','round']]
+                        eda = "loose edabits"
+                    res += ["%s %s of length %d" % (n, eda, req[1])]
+                elif domain == "matmul":
+                    res += [
+                        "%s matrix multiplications (%dx%d * %dx%d)"
+                        % (n, req[1][0], req[1][1], req[1][1], req[1][2])
+                    ]
+                elif req[0] != "all":
+                    res += ["%s %s %ss" % (n, domain, req[1])]
+            if self["all", "round"]:
+                res += ["% 12.0f virtual machine rounds" % self["all", "round"]]
             return res
+
         def __str__(self):
-            return ', '.join(self.pretty())
+            return ", ".join(self.pretty())
+
         def __repr__(self):
             return repr(dict(self))
 
     class ReqNode(object):
-        __slots__ = ['num', 'children', 'name', 'blocks']
+        __slots__ = ["num", "children", "name", "blocks"]
+
         def __init__(self, name):
             self.children = []
             self.name = name
             self.blocks = []
+
         def aggregate(self, *args):
             self.num = Tape.ReqNum()
             for block in self.blocks:
                 block.add_usage(self)
-            res = reduce(lambda x,y: x + y.aggregate(self.name),
-                         self.children, self.num)
+            res = reduce(
+                lambda x, y: x + y.aggregate(self.name), self.children, self.num
+            )
             return res
+
         def increment(self, data_type, num=1):
             self.num[data_type] += num
+
         def add_block(self, block):
             self.blocks.append(block)
 
     class ReqChild(object):
-        __slots__ = ['aggregator', 'nodes', 'parent']
+        __slots__ = ["aggregator", "nodes", "parent"]
+
         def __init__(self, aggregator, parent):
             self.aggregator = aggregator
             self.nodes = []
             self.parent = parent
+
         def aggregate(self, name):
             res = self.aggregator([node.aggregate() for node in self.nodes])
             try:
                 n_reps = self.aggregator([1])
-                n_rounds = res['all', 'round']
-                n_invs = res['all', 'inv']
+                n_rounds = res["all", "round"]
+                n_invs = res["all", "inv"]
                 if (n_invs / n_rounds) * 1000 < n_reps:
-                    print(self.nodes[0].blocks[0].name, 'blowing up rounds: ', \
-                        '(%d / %d) ** 3 < %d' % (n_rounds, n_reps, n_invs))
-            except:
+                    print(
+                        self.nodes[0].blocks[0].name,
+                        "blowing up rounds: ",
+                        "(%d / %d) ** 3 < %d" % (n_rounds, n_reps, n_invs),
+                    )
+            except Exception:
                 pass
             return res
+
         def add_node(self, tape, name):
             new_node = Tape.ReqNode(name)
             self.nodes.append(new_node)
             tape.req_node = new_node
 
-    def open_scope(self, aggregator, scope=False, name=''):
+    def open_scope(self, aggregator, scope=False, name=""):
         child = self.ReqChild(aggregator, self.req_node)
         self.req_node.children.append(child)
-        child.add_node(self, '%s-%d' % (name, len(self.basicblocks)))
+        child.add_node(self, "%s-%d" % (name, len(self.basicblocks)))
         self.start_new_basicblock(name=name)
         return child
 
@@ -1125,21 +1212,21 @@ class Tape:
         self.req_node = parent_req_node
         self.start_new_basicblock(outer_scope, name)
 
-    def require_bit_length(self, bit_length, t='p'):
-        if t == 'p':
+    def require_bit_length(self, bit_length, t="p"):
+        if t == "p":
             if self.program.prime:
-                if (bit_length >= self.program.prime.bit_length() - 1):
+                if bit_length >= self.program.prime.bit_length() - 1:
                     raise CompilerError(
-                        'required bit length %d too much for %d' % \
-                        (bit_length, self.program.prime))
-            self.req_bit_length[t] = max(bit_length + 1, \
-                                         self.req_bit_length[t])
+                        "required bit length %d too much for %d"
+                        % (bit_length, self.program.prime)
+                    )
+            self.req_bit_length[t] = max(bit_length + 1, self.req_bit_length[t])
         else:
             self.req_bit_length[t] = max(bit_length, self.req_bit_length)
 
     @staticmethod
     def read_instructions(tapename):
-        tape = open('Programs/Bytecode/%s.bc' % tapename, 'rb')
+        tape = open("Programs/Bytecode/%s.bc" % tapename, "rb")
         while tape.peek():
             yield inst_base.ParsedInstruction(tape)
 
@@ -1147,23 +1234,35 @@ class Tape:
         __slots__ = []
 
         def __bool__(self):
-            raise CompilerError('Cannot derive truth value from register, '
-                                "consider using 'compile.py -l'")
+            raise CompilerError(
+                "Cannot derive truth value from register, "
+                "consider using 'compile.py -l'"
+            )
 
     class Register(_no_truth):
         """
         Class for creating new registers. The register's index is automatically assigned
         based on the block's  reg_counter dictionary.
         """
-        __slots__ = ["reg_type", "program", "absolute_i", "relative_i", \
-                         "size", "vector", "vectorbase", "caller", \
-                         "can_eliminate", "duplicates"]
+
+        __slots__ = [
+            "reg_type",
+            "program",
+            "absolute_i",
+            "relative_i",
+            "size",
+            "vector",
+            "vectorbase",
+            "caller",
+            "can_eliminate",
+            "duplicates",
+        ]
         maximum_size = 2 ** (32 - inst_base.Instruction.code_length) - 1
 
         def __init__(self, reg_type, program, size=None, i=None):
-            """ Creates a new register.
-                reg_type must be one of those defined in RegType. """
-            if Compiler.instructions_base.get_global_instruction_type() == 'gf2n':
+            """Creates a new register.
+            reg_type must be one of those defined in RegType."""
+            if Compiler.instructions_base.get_global_instruction_type() == "gf2n":
                 if reg_type == RegType.ClearModp:
                     reg_type = RegType.ClearGF2N
                 elif reg_type == RegType.SecretModp:
@@ -1173,7 +1272,7 @@ class Tape:
             if size is None:
                 size = Compiler.instructions_base.get_global_vector_size()
             if size is not None and size > self.maximum_size:
-                raise CompilerError('vector too large: %d' % size)
+                raise CompilerError("vector too large: %d" % size)
             self.size = size
             self.vectorbase = self
             self.relative_i = 0
@@ -1183,7 +1282,7 @@ class Tape:
                 self.i = program.reg_counter[reg_type]
                 program.reg_counter[reg_type] += size
             else:
-                self.i = float('inf')
+                self.i = float("inf")
             self.vector = []
             self.can_eliminate = True
             self.duplicates = util.set_by_id([self])
@@ -1204,13 +1303,14 @@ class Tape:
             if self.size == size:
                 return
             else:
-                raise CompilerError('Mismatch of instruction and register size:'
-                                    ' %s != %s' % (self.size, size))
+                raise CompilerError(
+                    "Mismatch of instruction and register size:"
+                    " %s != %s" % (self.size, size)
+                )
 
         def set_vectorbase(self, vectorbase):
             if self.vectorbase is not self:
-                raise CompilerError('Cannot assign one register' \
-                                        'to several vectors')
+                raise CompilerError("Cannot assign one register" "to several vectors")
             self.relative_i = self.i - vectorbase.i
             self.vectorbase = vectorbase
 
@@ -1218,7 +1318,7 @@ class Tape:
             return Tape.Register(self.reg_type, self.program, size=size, i=i)
 
         def get_vector(self, base=0, size=None):
-            if size == None:
+            if size is None:
                 size = self.size
             if base == 0 and size == self.size:
                 return self
@@ -1227,7 +1327,7 @@ class Tape:
             res = self._new_by_number(self.i + base, size=size)
             res.set_vectorbase(self)
             self.create_vector_elements()
-            res.vector = self.vector[base:base+size]
+            res.vector = self.vector[base : base + size]
             return res
 
         def create_vector_elements(self):
@@ -1265,14 +1365,18 @@ class Tape:
 
         @property
         def is_gf2n(self):
-            return self.reg_type == RegType.ClearGF2N or \
-                self.reg_type == RegType.SecretGF2N
-        
+            return (
+                self.reg_type == RegType.ClearGF2N
+                or self.reg_type == RegType.SecretGF2N
+            )
+
         @property
         def is_clear(self):
-            return self.reg_type == RegType.ClearModp or \
-                self.reg_type == RegType.ClearGF2N or \
-                self.reg_type == RegType.ClearInt
+            return (
+                self.reg_type == RegType.ClearModp
+                or self.reg_type == RegType.ClearGF2N
+                or self.reg_type == RegType.ClearInt
+            )
 
         def __str__(self):
             return self.reg_type + str(self.i)

--- a/Programs/Source/test_args.mpc
+++ b/Programs/Source/test_args.mpc
@@ -15,7 +15,7 @@ if not compiler.options.columns:
 
 
 @compiler.register_function('testmpc')
-def main(compiler):
+def main():
     numrows = int(compiler.options.rows)
     numcolumns = int(compiler.options.columns)
     rows = range(numrows)

--- a/Programs/Source/test_args.mpc
+++ b/Programs/Source/test_args.mpc
@@ -1,0 +1,31 @@
+from Compiler.library import print_ln
+from Compiler.types import Matrix, sint
+from Compiler.compilerLib import Compiler
+
+
+usage = "usage: %prog [options] [args]"
+compiler = Compiler(usage=usage)
+compiler.parser.add_option("--rows", dest="rows")
+compiler.parser.add_option("--columns", dest="columns")
+compiler.parse_args()
+if not compiler.options.rows:
+    compiler.parser.error("--rows required")
+if not compiler.options.columns:
+    compiler.parser.error("--columns required")
+
+
+@compiler.register_function('testmpc')
+def main(compiler):
+    numrows = int(compiler.options.rows)
+    numcolumns = int(compiler.options.columns)
+    rows = range(numrows)
+    reports = Matrix(numrows, numcolumns, sint)
+    reports.assign_vector(
+        sint.get_input_from(0, size=numrows * numcolumns)
+    )
+    for row in rows:
+        print_ln(f"report[{row}]: %s", reports[row].reveal())
+
+
+if __name__ == "__main__":
+    compiler.compile_func()

--- a/README.md
+++ b/README.md
@@ -464,6 +464,35 @@ See the
 [documentation](https://mp-spdz.readthedocs.io/en/latest/Compiler.html#module-Compiler.circuit)
 for further examples.
 
+#### Compiling programs directly in Python
+
+You may prefer to not have an entirely static `.mpc` file to compile, and may want to compile based on dynamic inputs. For example, you may want to be able to compile with different sizes of input data without making a code change to the `.mpc` file. To handle this, the compiler an also be directly imported, and a function can be compiled with the following interface:
+
+```python
+# hello_world.mpc
+from Compiler.library import print_ln
+from Compiler.compilerLib import Compiler
+
+compiler = Compiler()
+
+@compiler.register_function('helloworld')
+def hello_world():
+    print_ln('hello world')
+
+if __name__ == "__main__":
+    compiler.compile_func()
+```
+
+You could then run this with:
+
+```bash
+python hello_world.mpc <compile args>
+```
+
+This is particularly useful if want to add new command line arguements specifically for your `.mpc` file. See [test_args.mpc](Programs/Source/test_args.mpc) for more details on this use case.
+
+Note that when using this approach, all objects provided in the high level interface (e.g. sint, print_ln) need to be imported, because the `.mpc` file is interpreted directly by Python (instead of being read by `compile.py`.
+
 #### Compiling and running programs from external directories
 
 Programs can also be edited, compiled and run from any directory with the above basic structure. So for a source file in `./Programs/Source/`, all MP-SPDZ scripts must be run from `./`. The `setup-online.sh` script must also be run from `./` to create the relevant data. For example:
@@ -966,7 +995,7 @@ After compiling the mpc file:
 You can benchmark the ORAM implementation as follows:
 
 1) Edit `Program/Source/gc_oram.mpc` to change size and to choose
-Circuit ORAM or linear scan without ORAM. 
+Circuit ORAM or linear scan without ORAM.
 2) Run `./compile.py -D gc_oram`. The `-D` argument instructs the
 compiler to remove dead code. This is useful for more complex programs
 such as this one.

--- a/README.md
+++ b/README.md
@@ -483,7 +483,7 @@ if __name__ == "__main__":
     compiler.compile_func()
 ```
 
-You could then run this with:
+You could then run this with the same args as used with `compile.py`:
 
 ```bash
 python hello_world.mpc <compile args>
@@ -491,7 +491,7 @@ python hello_world.mpc <compile args>
 
 This is particularly useful if want to add new command line arguements specifically for your `.mpc` file. See [test_args.mpc](Programs/Source/test_args.mpc) for more details on this use case.
 
-Note that when using this approach, all objects provided in the high level interface (e.g. sint, print_ln) need to be imported, because the `.mpc` file is interpreted directly by Python (instead of being read by `compile.py`.
+Note that when using this approach, all objects provided in the high level interface (e.g. sint, print_ln) need to be imported, because the `.mpc` file is interpreted directly by Python (instead of being read by `compile.py`.)
 
 #### Compiling and running programs from external directories
 

--- a/compile.py
+++ b/compile.py
@@ -12,100 +12,30 @@
 #
 # See the compiler documentation at https://mp-spdz.readthedocs.io
 # for details on the Compiler package
+from Compiler.compilerLib import Compiler
 
 
-from optparse import OptionParser
-from Compiler.program import defaults
-import Compiler
+def compilation(compiler):
+    prog = compiler.compile_file()
 
-def main():
-    usage = "usage: %prog [options] filename [args]"
-    parser = OptionParser(usage=usage)
-    parser.add_option("-n", "--nomerge",
-                      action="store_false", dest="merge_opens",
-                      default=defaults.merge_opens,
-                      help="don't attempt to merge open instructions")
-    parser.add_option("-o", "--output", dest="outfile",
-                      help="specify output file")
-    parser.add_option("-a", "--asm-output", dest="asmoutfile",
-                      help="asm output file for debugging")
-    parser.add_option("-g", "--galoissize", dest="galois",
-                      default=defaults.galois,
-                      help="bit length of Galois field")
-    parser.add_option("-d", "--debug", action="store_true", dest="debug",
-                      help="keep track of trace for debugging")
-    parser.add_option("-c", "--comparison", dest="comparison", default="log",
-                      help="comparison variant: log|plain|inv|sinv")
-    parser.add_option("-M", "--preserve-mem-order", action="store_true",
-                      dest="preserve_mem_order",
-                      default=defaults.preserve_mem_order,
-                      help="preserve order of memory instructions; possible efficiency loss")
-    parser.add_option("-O", "--optimize-hard", action="store_true",
-                      dest="optimize_hard", help="currently not in use")
-    parser.add_option("-u", "--noreallocate", action="store_true", dest="noreallocate",
-                      default=defaults.noreallocate, help="don't reallocate")
-    parser.add_option("-m", "--max-parallel-open", dest="max_parallel_open",
-                      default=defaults.max_parallel_open,
-                      help="restrict number of parallel opens")
-    parser.add_option("-D", "--dead-code-elimination", action="store_true",
-                      dest="dead_code_elimination",
-                      default=defaults.dead_code_elimination,
-                      help="eliminate instructions with unused result")
-    parser.add_option("-p", "--profile", action="store_true", dest="profile",
-                      help="profile compilation")
-    parser.add_option("-s", "--stop", action="store_true", dest="stop",
-                      help="stop on register errors")
-    parser.add_option("-R", "--ring", dest="ring", default=defaults.ring,
-                      help="bit length of ring (default: 0 for field)")
-    parser.add_option("-B", "--binary", dest="binary", default=defaults.binary,
-                      help="bit length of sint in binary circuit (default: 0 for arithmetic)")
-    parser.add_option("-F", "--field", dest="field", default=defaults.field,
-                      help="bit length of sint modulo prime (default: 64)")
-    parser.add_option("-P", "--prime", dest="prime", default=defaults.prime,
-                      help="prime modulus (default: not specified)")
-    parser.add_option("-I", "--insecure", action="store_true", dest="insecure",
-                      help="activate insecure functionality for benchmarking")
-    parser.add_option("-b", "--budget", dest="budget", default=defaults.budget,
-                      help="set budget for optimized loop unrolling "
-                      "(default: 100000)")
-    parser.add_option("-X", "--mixed", action="store_true", dest="mixed",
-                      help="mixing arithmetic and binary computation")
-    parser.add_option("-Y", "--edabit", action="store_true", dest="edabit",
-                      help="mixing arithmetic and binary computation using edaBits")
-    parser.add_option("-Z", "--split", default=defaults.split, dest="split",
-                      help="mixing arithmetic and binary computation "
-                      "using direct conversion if supported "
-                      "(number of parties as argument)")
-    parser.add_option("-C", "--CISC", action="store_true", dest="cisc",
-                      help="faster CISC compilation mode")
-    parser.add_option("-K", "--keep-cisc", dest="keep_cisc",
-                      help="don't translate CISC instructions")
-    parser.add_option("-l", "--flow-optimization", action="store_true",
-                      dest="flow_optimization", help="optimize control flow")
-    parser.add_option("-v", "--verbose", action="store_true", dest="verbose",
-                      help="more verbose output")
-    options,args = parser.parse_args()
-    if len(args) < 1:
-        parser.print_help()
-        return
+    if prog.public_input_file is not None:
+        print(
+            "WARNING: %s is required to run the program" % prog.public_input_file.name
+        )
 
-    if options.optimize_hard:
-        print('Note that -O/--optimize-hard currently has no effect')
 
-    def compilation():
-        prog = Compiler.run(args, options)
-
-        if prog.public_input_file is not None:
-            print('WARNING: %s is required to run the program' % \
-                  prog.public_input_file.name)
-
-    if options.profile:
+def main(compiler):
+    compiler.prep_compile()
+    if compiler.options.profile:
         import cProfile
-        p = cProfile.Profile().runctx('compilation()', globals(), locals())
-        p.dump_stats(args[0] + '.prof')
+
+        p = cProfile.Profile().runctx("compilation(compiler)", globals(), locals())
+        p.dump_stats(compiler.args[0] + ".prof")
         p.print_stats(2)
     else:
-        compilation()
+        compilation(compiler)
 
-if __name__ == '__main__':
-    main()
+
+if __name__ == "__main__":
+    compiler = Compiler()
+    main(compiler)

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -17,8 +17,7 @@ Compilation process
 
 The easiest way of using MP-SPDZ is using ``compile.py`` as
 described below. If you would like to run compilation directly from
-Python, see ``Scripts/direct_compilation_example.py``. It contains all
-the necessary setup steps.
+Python, see :ref:`Direct Compilation in Python`.
 
 After putting your code in ``Program/Source/<progname>.mpc``, run the
 compiler from the root directory as follows
@@ -139,6 +138,43 @@ computation:
    :py:func:`~Compiler.library.for_range_opt` and defer if statements
    to the run time.
 
+
+Direct Compilation in Python
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+You may prefer to not have an entirely static `.mpc` file to compile,
+and may want to compile based on dynamic inputs. For example, you may
+want to be able to compile with different sizes of input data without
+making a code change to the `.mpc` file. To handle this, the compiler
+an also be directly imported, and a function can be compiled with the
+following interface:
+
+.. code-block:: python
+    # hello_world.mpc
+    from Compiler.library import print_ln
+    from Compiler.compilerLib import Compiler
+
+    compiler = Compiler()
+
+    @compiler.register_function('helloworld')
+    def hello_world():
+        print_ln('hello world')
+
+    if __name__ == "__main__":
+        compiler.compile_func()
+
+
+You could then run this with the same args as used with `compile.py`:
+
+.. code-block:: bash
+    python hello_world.mpc <compile args>
+
+This is particularly useful if want to add new command line arguements
+specifically for your `.mpc` file. See [test_args.mpc](Programs/Source/test_args.mpc)
+for more details on this use case.
+
+Note that when using this approach, all objects provided in the high level
+interface (e.g. sint, print_ln) need to be imported, because the `.mpc` file
+is interpreted directly by Python (instead of being read by `compile.py`.)
 
 Compilation vs run time
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,7 @@
+from setuptools import setup, find_packages
+
+setup(
+    name='mp-spdz-compiler',
+    version='0.1.0',
+    packages=find_packages(include=['Compiler', 'Compiler.*'])
+)


### PR DESCRIPTION
As I've been playing around with MP-SPDZ, one thing I want to be able to do is add command line args for when I compile my MPC program (and not require code changes to compile for different data sizes, for example.)

This change is pretty big, (and looks bigger because I cleaned up PEP8 issues to make it easier to work in) but I believe that I maintained reverse compatibility with the `compile.py <mpc-program>` approach. I'm completely open to feedback on this, but I do think it provides a lot of useful flexibility.

My main goal was to be able to register a function to compile with a python decorator (inspired by [Flask](https://flask.palletsprojects.com/en/2.2.0/quickstart/).) I provided a new in the PR, but it looks something like:

```
# hello_world.mpc
from Compiler.library import print_ln
from Compiler.compilerLib import Compiler

compiler = Compiler()

@compiler.register_function('helloworld')
def hello_world():
    print_ln('hello world')

if __name__ == "__main__":
    compiler.compile_func()
```

I also added a `setup.py` file so that you can install the `Compiler` package in a virtualenv, and once in that env, you can then call this script:
```
python hello_world.mpc
```

My primary motivation was to provide access to the OptionParser, so that I could add my own options. (See the example in `test_args.mpc`.) 

I'm not sure if there is a test suite, but if there is some standard tests to run, I'm happy to do so to really make sure I didn't introduce any non-backwards compatible changes.