### PR TITLE
Fix broken import of GC.types to a relative import

### DIFF
--- a/Compiler/types.py
+++ b/Compiler/types.py
@@ -1654,7 +1654,7 @@ class regint(_register, _int):
 
     def _condition(self):
         if program.options.binary:
-            from GC.types import cbits
+            from .GC.types import cbits
             return cbits.get_type(64)(self)
         else:
             return cint(self)


### PR DESCRIPTION
The absolute import causes an ImportError.
The relative import is similar to the other 7 times GC.types is imported in this file.