### PR TITLE
PREP_DIR instead of hard-coded "Player-Data/" when suitable.

### DIFF
--- a/Processor/OnlineOptions.cpp
+++ b/Processor/OnlineOptions.cpp
@@ -28,7 +28,7 @@ OnlineOptions::OnlineOptions() : playerno(-1)
     direct = false;
     bucket_size = 4;
     security_parameter = DEFAULT_SECURITY;
-    cmd_private_input_file = "Player-Data/Input";
+    cmd_private_input_file = PREP_DIR "Input";
     cmd_private_output_file = "";
     file_prep_per_thread = false;
     trunc_error = DEFAULT_SECURITY;
@@ -62,7 +62,7 @@ OnlineOptions::OnlineOptions(ez::ezOptionParser& opt, int argc,
           0, // Required?
           1, // Number of args expected.
           0, // Delimiter if expecting multiple args.
-          "Prefix for input file path (default: Player-Data/Private-Input). "
+          "Prefix for input file path (default: " PREP_DIR "Private-Input). "
           "Input will be read from {prefix}-P{id}-{thread_id}.", // Help description.
           "-IF", // Flag token.
           "--input-file" // Flag token.

--- a/Processor/ProcessorBase.cpp
+++ b/Processor/ProcessorBase.cpp
@@ -21,7 +21,7 @@ void ProcessorBase::open_input_file(int my_num, int thread_num,
 {
     string tmp = prefix;
     if (prefix.empty())
-        tmp = "Player-Data/Input";
+        tmp = PREP_DIR "Input";
 
     open_input_file(get_parameterized_filename(my_num, thread_num, tmp));
 }

--- a/Utils/gen_input_fp.cpp
+++ b/Utils/gen_input_fp.cpp
@@ -128,7 +128,7 @@ int main(int argc, const char** argv) {
 	for (int i = 0; i < n; i++)
 		gfp(0).output(*out, false);
 	cerr << "Output written to " << output_name
-			<< ", copy to Player-Data/Private-Input-<playerno>" << endl;
+			<< ", copy to " PREP_DIR "Private-Input-<playerno>" << endl;
 
 	// Clean up file streams.
 	if(!use_stdin) {


### PR DESCRIPTION
Inside C++ code there was a few hard-coded references to "Player-Data/" directory when referring to default input folder. These strings may lead to inconsistencies if modifying `-DPREP_DIR` argument when compiling.