### PR TITLE
Use DoTS communication and I/O interface

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,6 @@
 [submodule "deps/SimplestOT_C"]
 	path = deps/SimplestOT_C
 	url = https://github.com/mkskeller/SimplestOT_C
+[submodule "deps/libdots"]
+	path = deps/libdots
+	url = https://github.com/dtrust-project/libdots.git

--- a/CONFIG
+++ b/CONFIG
@@ -68,7 +68,7 @@ endif
 
 LDLIBS = -lmpirxx -lmpir -lsodium $(MY_LDLIBS)
 LDLIBS +=  -Wl,-rpath -Wl,$(CURDIR)/local/lib -L$(CURDIR)/local/lib
-LDLIBS += -lboost_system -lssl -lcrypto
+LDLIBS += -lboost_system -lssl -lcrypto -ldots
 
 CFLAGS += -I./local/include
 

--- a/Makefile
+++ b/Makefile
@@ -347,6 +347,11 @@ $(SHARED_OTE): deps/libOTe/libOTe
 	cd deps/libOTe; \
 	python3 build.py --install=$(CURDIR)/local -- -DBUILD_SHARED_LIBS=1 $(OTE_OPTS)
 
+local/lib/libdots.so:
+	$(MAKE) -C deps/libdots libdots.so
+	cp deps/libdots/libdots.so $(CURDIR)/local/lib
+	cp -R deps/libdots/include/. $(CURDIR)/local/include
+
 cmake:
 	wget https://github.com/Kitware/CMake/releases/download/v3.24.1/cmake-3.24.1.tar.gz
 	tar xzvf cmake-3.24.1.tar.gz

--- a/Networking/DotsPlayer.cpp
+++ b/Networking/DotsPlayer.cpp
@@ -1,8 +1,111 @@
 #include "DotsPlayer.h"
+#include "Networking/Player.h"
+#include <dots.h>
 
-DotsPlayer::DotsPlayer(Names& names, string id, vector<int> socks) :
-    MultiPlayer<int>(names, id) {
-    sockets = socks;
+bool DotsPlayer::envIsInitted = false;
+
+DotsPlayer::DotsPlayer() : Player(Names(dots_world_rank, dots_world_size)) {
+    if (envIsInitted) {
+        envIsInitted = true;
+        isFirstPlayer = true;
+    } else {
+        isFirstPlayer = false;
+        nonFirstSockets.resize(dots_world_size);
+        for (size_t i = 0; i < dots_world_size; i++) {
+            if (i == dots_world_rank) {
+                continue;
+            }
+            int socket = dots_open_socket(i);
+            if (socket < 0) {
+                throw runtime_error("Failed to open subsequent DoTS socket");
+            }
+            nonFirstSockets[i] = socket;
+        }
+    }
+}
+
+int DotsPlayer::num_players() const {
+    return dots_world_size;
+}
+
+int DotsPlayer::my_num() const {
+    return dots_world_rank;
+}
+
+void DotsPlayer::send_to_no_stats(int player, const octetStream& o) const {
+    if (isFirstPlayer) {
+        cout << "First player sending to " << player << endl;
+        if (dots_msg_send(o.get_data(), o.get_length(), (size_t) player)) {
+            throw runtime_error("Error in dots_msg_send");
+        }
+        cout << "First player sent to " << player << endl;
+    } else {
+        cout << "Non-first player sending to " << player << endl;
+        send(nonFirstSockets[player], o.get_data(), o.get_length());
+        cout << "Non-first player sent to " << player << endl;
+    }
+}
+
+void DotsPlayer::receive_player_no_stats(int player, octetStream& o) const {
+    if (isFirstPlayer) {
+        cout << "First player receiving from " << player << endl;
+        if (dots_msg_recv(o.get_data(), o.get_length(), (size_t) player, NULL)) {
+            throw runtime_error("Error in dots_msg_send");
+        }
+        cout << "First player received from " << player << endl;
+    } else {
+        cout << "Non-first player receiving from " << player << endl;
+        receive(nonFirstSockets[player], o.get_data(), o.get_length());
+        cout << "Non-first player received from " << player << endl;
+    }
+}
+
+void DotsPlayer::exchange_no_stats(int other, const octetStream& to_send,
+        octetStream& to_receive) const {
+    send_to_no_stats(other, to_send);
+    receive_player_no_stats(other, to_receive);
+}
+
+void DotsPlayer::pass_around_no_stats(const octetStream& to_send,
+      octetStream& to_receive, int offset) const {
+    send_to_no_stats(get_player(offset), to_send);
+    receive_player_no_stats(get_player(-offset), to_receive);
+}
+
+void DotsPlayer::Broadcast_Receive_no_stats(vector<octetStream>& o) const {
+    for (int i = 0; i < num_players(); i++) {
+        if (i == my_num()) {
+            continue;
+        }
+        send_to_no_stats(i, o[my_num()]);
+    }
+    for (int i = 0; i < num_players(); i++) {
+        if (i == my_num()) {
+            continue;
+        }
+        receive_player_no_stats(i, o[i]);
+    }
+}
+
+void DotsPlayer::send_receive_all_no_stats(const vector<vector<bool>>& channels,
+        const vector<octetStream>& to_send,
+        vector<octetStream>& to_receive) const {
+    for (int i = 0; i < num_players(); i++) {
+        if (i == my_num()) {
+            continue;
+        }
+        if (channels[my_num()][i]) {
+            send_to_no_stats(i, to_send[i]);
+        }
+    }
+    for (int i = 0; i < num_players(); i++) {
+        if (i == my_num()) {
+            continue;
+        }
+        if (channels[my_num()][i]) {
+            receive_player_no_stats(i, to_receive[i]);
+        }
+    }
 }
 
 DotsPlayer::~DotsPlayer() {}

--- a/Networking/DotsPlayer.cpp
+++ b/Networking/DotsPlayer.cpp
@@ -69,7 +69,9 @@ DotsPlayer::DotsPlayer(const string& id) :
                 send(socket, (octet*) purpose, PURPOSE_LEN);
                 sockets[i] = socket;
 
+#ifdef DEBUG_NETWORKING
                 cout << "Claiming socket for " << id << endl;
+#endif
             } else {
                 /* For lesser ranks, get the purpose by reading from the
                  * socket. */
@@ -79,10 +81,15 @@ DotsPlayer::DotsPlayer(const string& id) :
                 string purpose_str(purpose);
                 if (purpose_str == id) {
                     /* If the purpose is correct, use the socket. */
-                    cout << "Received socket for " << id << ", which matches " << id << endl;
                     sockets[i] = socket;
+#ifdef DEBUG_NETWORKING
+                    cout << "Received socket for " << id << ", which matches " << id << endl;
+#endif
                 } else {
+#ifdef DEBUG_NETWORKING
                     cout << "Received socket for " << id << ", but I wanted " << id << endl;
+#endif
+
                     /* Put the socket in the receivedSockets map, signal that it
                      * it's been filled, and sleep until someone else picks up
                      * our socket. */
@@ -120,12 +127,24 @@ void DotsPlayer::send_to_no_stats(int player, const octetStream& o) const {
     octet lenbuf[LENGTH_SIZE];
     encode_length(lenbuf, o.get_length(), LENGTH_SIZE);
 
+#ifdef VERBOSE_COMM
+    cout << id << ": Sending " << o.get_length() << " bytes to " << player << endl;
+#endif
+
     send(sockets[player], lenbuf, sizeof(lenbuf));
     send(sockets[player], o.get_data(), o.get_length());
+
+#ifdef VERBOSE_COMM
+    cout << id << ": Sent " << o.get_length() << " bytes to " << player << endl;
+#endif
 }
 
 void DotsPlayer::receive_player_no_stats(int player, octetStream& o) const {
     octet lenbuf[LENGTH_SIZE];
+
+#ifdef VERBOSE_COMM
+    cout << id << ": Receiving from " << player << endl;
+#endif
 
     receive(sockets[player], lenbuf, LENGTH_SIZE);
 
@@ -135,17 +154,40 @@ void DotsPlayer::receive_player_no_stats(int player, octetStream& o) const {
     octet *ptr = o.append(len);
 
     receive(sockets[player], ptr, len);
+
+#ifdef VERBOSE_COMM
+    cout << id << ": Received " << o.get_length() << " bytes from " << player << endl;
+#endif
 }
 
 size_t DotsPlayer::send_no_stats(int player, const PlayerBuffer& buffer,
         bool block __attribute__((unused))) const {
+
+#ifdef VERBOSE_COMM
+    cout << id << ": [Player buffer] Sending " << buffer.size << " bytes to " << player << endl;
+#endif
     send(sockets[player], buffer.data, buffer.size);
+
+#ifdef VERBOSE_COMM
+    cout << id << ": [Player buffer] Sent " << buffer.size << " bytes to " << player << endl;
+#endif
+
     return buffer.size;
 }
 
 size_t DotsPlayer::recv_no_stats(int player, const PlayerBuffer& buffer,
         bool block __attribute__((unused))) const {
+
+#ifdef VERBOSE_COMM
+    cout << id << ": [Player buffer] Receiving " << buffer.size << " bytes from " << player << endl;
+#endif
+
     receive(sockets[player], buffer.data, buffer.size);
+
+#ifdef VERBOSE_COMM
+    cout << id << ": [Player buffer] Received " << buffer.size << " bytes from " << player << endl;
+#endif
+
     return buffer.size;
 }
 

--- a/Networking/DotsPlayer.cpp
+++ b/Networking/DotsPlayer.cpp
@@ -64,8 +64,8 @@ DotsPlayer::DotsPlayer(const string& id) :
                  * so we send the ID to the other side to notify it of the
                  * owner. */
                 char purpose[PURPOSE_LEN];
-                memset(purpose, '\0', PURPOSE_LEN);
-                strncpy(purpose, id.c_str(), PURPOSE_LEN);
+                strncpy(purpose, id.c_str(), PURPOSE_LEN - 1);
+                purpose[PURPOSE_LEN - 1] = '\0';
                 send(socket, (octet*) purpose, PURPOSE_LEN);
                 sockets[i] = socket;
 

--- a/Networking/DotsPlayer.cpp
+++ b/Networking/DotsPlayer.cpp
@@ -1,0 +1,8 @@
+#include "DotsPlayer.h"
+
+DotsPlayer::DotsPlayer(Names& names, string id, vector<int> socks) :
+    MultiPlayer<int>(names, id) {
+    sockets = socks;
+}
+
+DotsPlayer::~DotsPlayer() {}

--- a/Networking/DotsPlayer.h
+++ b/Networking/DotsPlayer.h
@@ -1,17 +1,30 @@
 #ifndef NETWORKING_DOTSPLAYER_H_
 #define NETWORKING_DOTSPLAYER_H_
 
+#include <condition_variable>
+#include <mutex>
+#include <string>
+#include <unordered_map>
 #include "Networking/Player.h"
 
 class DotsPlayer : public Player {
   private:
+    /* Socket matching. */
+    static mutex receivedSocketsLock;
+    static unordered_map<string, int> receivedSockets;
+    static condition_variable socketReceived;
+
+    string id;
     vector<int> sockets;
 
   public:
-    DotsPlayer();
+    DotsPlayer(const string& id);
     ~DotsPlayer() override;
 
-    virtual inline string get_id() const override;
+    virtual inline string get_id() const override {
+        return id;
+    }
+
     virtual int num_players() const override;
     virtual int my_num() const override;
 

--- a/Networking/DotsPlayer.h
+++ b/Networking/DotsPlayer.h
@@ -13,12 +13,16 @@ class DotsPlayer : public Player {
     DotsPlayer();
     ~DotsPlayer() override;
 
+    virtual inline string get_id() const override;
     virtual int num_players() const override;
     virtual int my_num() const override;
 
     virtual void send_to_no_stats(int player,
             const octetStream& o) const override;
     virtual void receive_player_no_stats(int i, octetStream& o) const override;
+
+    virtual size_t send_no_stats(int, const PlayerBuffer&, bool) const override;
+    virtual size_t recv_no_stats(int, const PlayerBuffer&, bool) const override;
 
     virtual void exchange_no_stats(int other, const octetStream& to_send,
             octetStream& to_receive) const override;

--- a/Networking/DotsPlayer.h
+++ b/Networking/DotsPlayer.h
@@ -1,0 +1,12 @@
+#ifndef NETWORKING_DOTSPLAYER_H_
+#define NETWORKING_DOTSPLAYER_H_
+
+#include "Networking/Player.h"
+
+class DotsPlayer : public MultiPlayer<int> {
+  public:
+    DotsPlayer(Names& names, string id, vector<int> socks);
+    ~DotsPlayer() override;
+};
+
+#endif

--- a/Networking/DotsPlayer.h
+++ b/Networking/DotsPlayer.h
@@ -3,10 +3,35 @@
 
 #include "Networking/Player.h"
 
-class DotsPlayer : public MultiPlayer<int> {
+class DotsPlayer : public Player {
+  private:
+    static bool envIsInitted;
+    bool isFirstPlayer;
+    vector<int> nonFirstSockets;
+
   public:
-    DotsPlayer(Names& names, string id, vector<int> socks);
+    DotsPlayer();
     ~DotsPlayer() override;
+
+    virtual int num_players() const override;
+    virtual int my_num() const override;
+
+    virtual void send_to_no_stats(int player,
+            const octetStream& o) const override;
+    virtual void receive_player_no_stats(int i, octetStream& o) const override;
+
+    virtual void exchange_no_stats(int other, const octetStream& to_send,
+            octetStream& to_receive) const override;
+
+    virtual void pass_around_no_stats(const octetStream& to_send,
+            octetStream& to_receive, int offset) const override;
+
+    virtual void Broadcast_Receive_no_stats(
+            vector<octetStream>& o) const override;
+
+    virtual void send_receive_all_no_stats(const vector<vector<bool>>& channels,
+            const vector<octetStream>& to_send,
+            vector<octetStream>& to_receive) const override;
 };
 
 #endif

--- a/Networking/DotsPlayer.h
+++ b/Networking/DotsPlayer.h
@@ -5,9 +5,7 @@
 
 class DotsPlayer : public Player {
   private:
-    static bool envIsInitted;
-    bool isFirstPlayer;
-    vector<int> nonFirstSockets;
+    vector<int> sockets;
 
   public:
     DotsPlayer();

--- a/Networking/Player.cpp
+++ b/Networking/Player.cpp
@@ -226,10 +226,8 @@ MultiPlayer<T>::MultiPlayer(const Names& Nms, const string& id) :
 PlainPlayer::PlainPlayer(const Names& Nms, const string& id) :
         MultiPlayer<int>(Nms, id)
 {
-  if (Nms.num_players() > 1) {
+  if (Nms.num_players() > 1)
     setup_sockets(Nms.names, Nms.ports, id, *Nms.server);
-    socketsSelfAllocated = true;
-  }
 }
 
 
@@ -238,15 +236,9 @@ PlainPlayer::PlainPlayer(const Names& Nms, int id_base) :
 {
 }
 
-PlainPlayer::PlainPlayer(const Names& Nms, const string& id, vector<int> socks) :
-        MultiPlayer<int>(Nms, id) {
-  sockets = socks;
-  socketsSelfAllocated = false;
-}
-
 PlainPlayer::~PlainPlayer()
 {
-  if (num_players() > 1 && socketsSelfAllocated)
+  if (num_players() > 1)
     {
       /* Close down the sockets */
       for (auto socket : sockets)

--- a/Networking/Player.cpp
+++ b/Networking/Player.cpp
@@ -226,8 +226,10 @@ MultiPlayer<T>::MultiPlayer(const Names& Nms, const string& id) :
 PlainPlayer::PlainPlayer(const Names& Nms, const string& id) :
         MultiPlayer<int>(Nms, id)
 {
-  if (Nms.num_players() > 1)
+  if (Nms.num_players() > 1) {
     setup_sockets(Nms.names, Nms.ports, id, *Nms.server);
+    socketsSelfAllocated = true;
+  }
 }
 
 
@@ -236,9 +238,15 @@ PlainPlayer::PlainPlayer(const Names& Nms, int id_base) :
 {
 }
 
+PlainPlayer::PlainPlayer(const Names& Nms, const string& id, vector<int> socks) :
+        MultiPlayer<int>(Nms, id) {
+  sockets = socks;
+  socketsSelfAllocated = false;
+}
+
 PlainPlayer::~PlainPlayer()
 {
-  if (num_players() > 1)
+  if (num_players() > 1 && socketsSelfAllocated)
     {
       /* Close down the sockets */
       for (auto socket : sockets)

--- a/Networking/Player.h
+++ b/Networking/Player.h
@@ -451,6 +451,9 @@ class PlainPlayer : public MultiPlayer<int>
   void setup_sockets(const vector<string>& names, const vector<int>& ports,
       const string& id_base, ServerSocket& server);
 
+private:
+  bool socketsSelfAllocated;
+
 public:
   /**
    * Start a new set of unencrypted connections.
@@ -460,6 +463,7 @@ public:
   PlainPlayer(const Names& Nms, const string& id);
   // legacy interface
   PlainPlayer(const Names& Nms, int id_base = 0);
+  PlainPlayer(const Names& Nms, const string& id, vector<int> sockets);
   ~PlainPlayer();
 
   size_t send_no_stats(int player, const PlayerBuffer& buffer, bool block) const;

--- a/Networking/Player.h
+++ b/Networking/Player.h
@@ -451,9 +451,6 @@ class PlainPlayer : public MultiPlayer<int>
   void setup_sockets(const vector<string>& names, const vector<int>& ports,
       const string& id_base, ServerSocket& server);
 
-private:
-  bool socketsSelfAllocated;
-
 public:
   /**
    * Start a new set of unencrypted connections.
@@ -463,7 +460,6 @@ public:
   PlainPlayer(const Names& Nms, const string& id);
   // legacy interface
   PlainPlayer(const Names& Nms, int id_base = 0);
-  PlainPlayer(const Names& Nms, const string& id, vector<int> sockets);
   ~PlainPlayer();
 
   size_t send_no_stats(int player, const PlayerBuffer& buffer, bool block) const;

--- a/OT/NPartyTripleGenerator.hpp
+++ b/OT/NPartyTripleGenerator.hpp
@@ -71,10 +71,10 @@ Spdz2kTripleGenerator<T>::Spdz2kTripleGenerator(const OTTripleSetup& setup,
 
 template<class T>
 OTTripleGenerator<T>::OTTripleGenerator(const OTTripleSetup& setup,
-        const Names& names, int thread_num, int _nTriples, int nloops,
+        const Names& names __attribute__((unused)), int thread_num,
+        int _nTriples, int nloops,
         MascotParams& machine, mac_key_type mac_key, Player* parentPlayer) :
-        globalPlayer(parentPlayer ? *parentPlayer : *new PlainPlayer(names,
-                to_string(thread_num))),
+        globalPlayer(parentPlayer ? *parentPlayer : *new DotsPlayer()),
         parentPlayer(parentPlayer),
         thread_num(thread_num),
         mac_key(mac_key),

--- a/OT/NPartyTripleGenerator.hpp
+++ b/OT/NPartyTripleGenerator.hpp
@@ -74,7 +74,7 @@ OTTripleGenerator<T>::OTTripleGenerator(const OTTripleSetup& setup,
         const Names& names __attribute__((unused)), int thread_num,
         int _nTriples, int nloops,
         MascotParams& machine, mac_key_type mac_key, Player* parentPlayer) :
-        globalPlayer(parentPlayer ? *parentPlayer : *new DotsPlayer()),
+        globalPlayer(parentPlayer ? *parentPlayer : *new DotsPlayer(to_string(thread_num))),
         parentPlayer(parentPlayer),
         thread_num(thread_num),
         mac_key(mac_key),

--- a/Processor/Machine.h
+++ b/Processor/Machine.h
@@ -67,6 +67,7 @@ class Machine : public BaseMachine
   bool receive_threads;
   int max_broadcast;
   bool use_encryption;
+  bool use_dots;
   bool live_prep;
 
   OnlineOptions opts;
@@ -75,9 +76,8 @@ class Machine : public BaseMachine
 
   static void init_binary_domains(int security_parameter, int lg2);
 
-  Machine(Names& playerNames, bool use_encryption = true,
-          vector<int> dotsSockets = {}, const OnlineOptions opts = sint(),
-          int lg2 = 0);
+  Machine(Names& playerNames, bool use_encryption = true, bool use_dots = false,
+          const OnlineOptions opts = sint(), int lg2 = 0);
   ~Machine();
 
   const Names& get_N() { return N; }

--- a/Processor/Machine.h
+++ b/Processor/Machine.h
@@ -76,7 +76,8 @@ class Machine : public BaseMachine
   static void init_binary_domains(int security_parameter, int lg2);
 
   Machine(Names& playerNames, bool use_encryption = true,
-          const OnlineOptions opts = sint(), int lg2 = 0);
+          vector<int> dotsSockets = {}, const OnlineOptions opts = sint(),
+          int lg2 = 0);
   ~Machine();
 
   const Names& get_N() { return N; }

--- a/Processor/Machine.hpp
+++ b/Processor/Machine.hpp
@@ -5,6 +5,7 @@
 
 #include "Memory.hpp"
 #include "Online-Thread.hpp"
+#include "Networking/DotsPlayer.h"
 #include "Protocols/Hemi.hpp"
 #include "Protocols/fake-stuff.hpp"
 
@@ -53,7 +54,7 @@ void Machine<sint, sgf2n>::init_binary_domains(int security_parameter, int lg2)
 
 template<class sint, class sgf2n>
 Machine<sint, sgf2n>::Machine(Names& playerNames, bool use_encryption,
-    const OnlineOptions opts, int lg2)
+        vector<int> dotsSockets, const OnlineOptions opts, int lg2)
   : my_number(playerNames.my_num()), N(playerNames),
     direct(opts.direct), opening_sum(opts.opening_sum),
     receive_threads(opts.receive_threads), max_broadcast(opts.max_broadcast),
@@ -75,10 +76,14 @@ Machine<sint, sgf2n>::Machine(Names& playerNames, bool use_encryption,
   mkdir_p(PREP_DIR);
 
   string id = "machine";
-  if (use_encryption)
-    P = new CryptoPlayer(N, id);
-  else
-    P = new PlainPlayer(N, id);
+  if (dotsSockets.size() == 0) {
+      if (use_encryption)
+        P = new CryptoPlayer(N, id);
+      else
+        P = new PlainPlayer(N, id);
+  } else {
+      P = new DotsPlayer(N, id, dotsSockets);
+  }
 
   if (opts.live_prep)
     {

--- a/Processor/Machine.hpp
+++ b/Processor/Machine.hpp
@@ -54,7 +54,7 @@ void Machine<sint, sgf2n>::init_binary_domains(int security_parameter, int lg2)
 
 template<class sint, class sgf2n>
 Machine<sint, sgf2n>::Machine(Names& playerNames, bool use_encryption,
-        vector<int> dotsSockets, const OnlineOptions opts, int lg2)
+        bool use_dots, const OnlineOptions opts, int lg2)
   : my_number(playerNames.my_num()), N(playerNames),
     direct(opts.direct), opening_sum(opts.opening_sum),
     receive_threads(opts.receive_threads), max_broadcast(opts.max_broadcast),
@@ -76,13 +76,13 @@ Machine<sint, sgf2n>::Machine(Names& playerNames, bool use_encryption,
   mkdir_p(PREP_DIR);
 
   string id = "machine";
-  if (dotsSockets.size() == 0) {
+  if (use_dots) {
+      P = new DotsPlayer();
+  } else {
       if (use_encryption)
         P = new CryptoPlayer(N, id);
       else
         P = new PlainPlayer(N, id);
-  } else {
-      P = new DotsPlayer(N, id, dotsSockets);
   }
 
   if (opts.live_prep)

--- a/Processor/Machine.hpp
+++ b/Processor/Machine.hpp
@@ -58,7 +58,8 @@ Machine<sint, sgf2n>::Machine(Names& playerNames, bool use_encryption,
   : my_number(playerNames.my_num()), N(playerNames),
     direct(opts.direct), opening_sum(opts.opening_sum),
     receive_threads(opts.receive_threads), max_broadcast(opts.max_broadcast),
-    use_encryption(use_encryption), live_prep(opts.live_prep), opts(opts)
+    use_encryption(use_encryption), use_dots(use_dots),
+    live_prep(opts.live_prep), opts(opts)
 {
   OnlineOptions::singleton = opts;
 

--- a/Processor/Machine.hpp
+++ b/Processor/Machine.hpp
@@ -78,7 +78,7 @@ Machine<sint, sgf2n>::Machine(Names& playerNames, bool use_encryption,
 
   string id = "machine";
   if (use_dots) {
-      P = new DotsPlayer();
+      P = new DotsPlayer(id);
   } else {
       if (use_encryption)
         P = new CryptoPlayer(N, id);

--- a/Processor/Online-Thread.hpp
+++ b/Processor/Online-Thread.hpp
@@ -53,7 +53,7 @@ void thread_info<sint, sgf2n>::Sub_Main_Func()
   string id = "thread" + to_string(num);
   if (machine.use_dots)
     {
-      player = new DotsPlayer();
+      player = new DotsPlayer(id);
     }
   else if (machine.use_encryption)
     {

--- a/Processor/Online-Thread.hpp
+++ b/Processor/Online-Thread.hpp
@@ -6,6 +6,7 @@
 #include "Processor/Machine.h"
 #include "Processor/Processor.h"
 #include "Networking/CryptoPlayer.h"
+#include "Networking/DotsPlayer.h"
 #include "Protocols/ShuffleSacrifice.h"
 #include "Protocols/LimitedPrep.h"
 #include "FHE/FFT.h"
@@ -50,7 +51,11 @@ void thread_info<sint, sgf2n>::Sub_Main_Func()
 #endif
   Player* player;
   string id = "thread" + to_string(num);
-  if (machine.use_encryption)
+  if (machine.use_dots)
+    {
+      player = new DotsPlayer();
+    }
+  else if (machine.use_encryption)
     {
 #ifdef VERBOSE_OPTIONS
       cerr << "Using encrypted single-threaded communication" << endl;

--- a/Processor/OnlineMachine.h
+++ b/Processor/OnlineMachine.h
@@ -12,9 +12,6 @@
 
 class OnlineMachine
 {
-private:
-    vector<int> dotsSockets;
-
 protected:
     int argc;
     const char** argv;
@@ -25,6 +22,7 @@ protected:
     Names playerNames;
 
     bool use_encryption;
+    bool use_dots;
 
     ez::ezOptionParser& opt;
 

--- a/Processor/OnlineMachine.h
+++ b/Processor/OnlineMachine.h
@@ -12,6 +12,9 @@
 
 class OnlineMachine
 {
+private:
+    vector<int> dotsSockets;
+
 protected:
     int argc;
     const char** argv;

--- a/Processor/OnlineMachine.hpp
+++ b/Processor/OnlineMachine.hpp
@@ -158,6 +158,8 @@ void OnlineMachine::start_networking()
         if (dots_env_init()) {
             throw runtime_error("Error initializing DoTS environment");
         }
+
+        playerNames.init(dots_world_rank, -1, vector<string>(dots_world_size));
     } else {
         opt.get("--portnumbase")->getInt(pnbase);
         opt.get("--hostname")->getString(hostname);

--- a/Processor/OnlineMachine.hpp
+++ b/Processor/OnlineMachine.hpp
@@ -7,6 +7,7 @@
 #include "Tools/ezOptionParser.h"
 #include "Networking/Server.h"
 #include "Networking/CryptoPlayer.h"
+#include "Networking/DotsPlayer.h"
 #include <iostream>
 #include <map>
 #include <string>
@@ -69,6 +70,14 @@ OnlineMachine::OnlineMachine(int argc, const char** argv, ez::ezOptionParser& op
       "Filename containing list of party ip addresses. Alternative to --hostname and running Server.x for startup coordination.", // Help description.
       "-ip", // Flag token.
       "--ip-file-name" // Flag token.
+    );
+    opt.add(
+          "", // Default.
+          0, // Required?
+          0, // Number of args expected.
+          0, // Delimiter if expecting multiple args.
+          "Use DoTS.", // Help description.
+          "--dots" // Flag token.
     );
 
     if (nplayers == 0)
@@ -139,48 +148,88 @@ void OnlineMachine::start_networking()
     int pnbase;
     int my_port;
 
-    opt.get("--portnumbase")->getInt(pnbase);
-    opt.get("--hostname")->getString(hostname);
-    opt.get("--ip-file-name")->getString(ipFileName);
+    if (opt.isSet("--dots")) {
+        if (opt.isSet("--encrypted")) {
+            throw runtime_error("Cannot use encryption over DoTS network");
+        }
 
-    ez::OptionGroup* mp_opt = opt.get("--my-port");
-    if (mp_opt->isSet)
-      mp_opt->getInt(my_port);
-    else
-      my_port = Names::DEFAULT_PORT;
+        string line;
+        string int_str;
+        stringstream line_stream;
 
-    int mynum = online_opts.playerno;
-    int playerno = online_opts.playerno;
+        /* Rank. */
+        getline(cin, line);
+        line_stream = stringstream(line);
+        int rank = stoi(line);
 
-    if (ipFileName.size() > 0) {
-      if (my_port != Names::DEFAULT_PORT)
-        throw runtime_error("cannot set port number when using IP file");
-      if (nplayers == 0 and opt.isSet("-N"))
-        opt.get("-N")->getInt(nplayers);
-      playerNames.init(playerno, pnbase, ipFileName, nplayers);
+        /* Discard input FDs. */
+        getline(cin, line);
+
+        /* Discard output FDs. */
+        getline(cin, line);
+
+        /* Socket FDs. */
+        getline(cin, line);
+        line_stream = stringstream(line);
+        vector<string> names;
+        while (getline(line_stream, int_str, ' ')) {
+            names.push_back(int_str);
+            dotsSockets.push_back(stoi(int_str));
+        }
+
+        cout << rank << ": " << getpid() << '\n';
+        volatile bool loop = true;
+        while (loop) {}
+
+        playerNames.init(rank, -1, names);
     } else {
-      if (not opt.get("-ext-server")->isSet)
-      {
-        if (nplayers == 0)
-          opt.get("-N")->getInt(nplayers);
-        Server::start_networking(playerNames, mynum, nplayers,
-            hostname, pnbase, my_port);
-      }
-      else
-      {
-        cerr << "Relying on external Server.x" << endl;
-        playerNames.init(playerno, pnbase, my_port, hostname.c_str());
-      }
+        opt.get("--portnumbase")->getInt(pnbase);
+        opt.get("--hostname")->getString(hostname);
+        opt.get("--ip-file-name")->getString(ipFileName);
+
+        ez::OptionGroup* mp_opt = opt.get("--my-port");
+        if (mp_opt->isSet)
+          mp_opt->getInt(my_port);
+        else
+          my_port = Names::DEFAULT_PORT;
+
+        int mynum = online_opts.playerno;
+        int playerno = online_opts.playerno;
+
+        if (ipFileName.size() > 0) {
+          if (my_port != Names::DEFAULT_PORT)
+            throw runtime_error("cannot set port number when using IP file");
+          if (nplayers == 0 and opt.isSet("-N"))
+            opt.get("-N")->getInt(nplayers);
+          playerNames.init(playerno, pnbase, ipFileName, nplayers);
+        } else {
+          if (not opt.get("-ext-server")->isSet)
+          {
+            if (nplayers == 0)
+              opt.get("-N")->getInt(nplayers);
+            Server::start_networking(playerNames, mynum, nplayers,
+                hostname, pnbase, my_port);
+          }
+          else
+          {
+            cerr << "Relying on external Server.x" << endl;
+            playerNames.init(playerno, pnbase, my_port, hostname.c_str());
+          }
+        }
     }
 }
 
 inline
 Player* OnlineMachine::new_player(const string& id_base)
 {
-    if (use_encryption)
-        return new CryptoPlayer(playerNames, id_base);
-    else
-        return new PlainPlayer(playerNames, id_base);
+    if (dotsSockets.size() == 0) {
+        if (use_encryption)
+            return new CryptoPlayer(playerNames, id_base);
+        else
+            return new PlainPlayer(playerNames, id_base);
+    } else {
+        return new DotsPlayer(playerNames, id_base, dotsSockets);
+    }
 }
 
 template<class T, class U>
@@ -190,7 +239,7 @@ int OnlineMachine::run()
     try
 #endif
     {
-        Machine<T, U>(playerNames, use_encryption, online_opts, lg2).run(
+        Machine<T, U>(playerNames, use_encryption, dotsSockets, online_opts, lg2).run(
                 online_opts.progname);
 
         if (online_opts.verbose)

--- a/Processor/OnlineMachine.hpp
+++ b/Processor/OnlineMachine.hpp
@@ -196,10 +196,10 @@ void OnlineMachine::start_networking()
 }
 
 inline
-Player* OnlineMachine::new_player(const string& id_base __attribute__((unused)))
+Player* OnlineMachine::new_player(const string& id_base)
 {
     if (use_dots) {
-        return new DotsPlayer();
+        return new DotsPlayer(id_base);
     } else {
         if (use_encryption)
             return new CryptoPlayer(playerNames, id_base);

--- a/Processor/OnlineOptions.cpp
+++ b/Processor/OnlineOptions.cpp
@@ -294,7 +294,8 @@ void OnlineOptions::finalize(ez::ezOptionParser& opt, int argc,
     opt.footer += "\nSee also https://mp-spdz.readthedocs.io/en/latest/networking.html "
             "for documentation on the networking setup.\n";
 
-    if (allArgs.size() != 3u - opt.isSet("-p"))
+    bool hasExternPlayerNo = opt.isSet("-p") || opt.isSet("--dots");
+    if (allArgs.size() != 3u - hasExternPlayerNo)
     {
         cerr << "ERROR: incorrect number of arguments to " << argv[0] << endl;
         cerr << "Arguments given were:\n";
@@ -308,9 +309,9 @@ void OnlineOptions::finalize(ez::ezOptionParser& opt, int argc,
     {
         if (opt.isSet("-p"))
             opt.get("-p")->getInt(playerno);
-        else
+        else if (!opt.isSet("--dots"))
             sscanf((*allArgs[1]).c_str(), "%d", &playerno);
-        progname = *allArgs[2 - opt.isSet("-p")];
+        progname = *allArgs[2 - hasExternPlayerNo];
     }
 
     if (!opt.gotRequired(badOptions))

--- a/Processor/Processor.hpp
+++ b/Processor/Processor.hpp
@@ -78,7 +78,7 @@ Processor<sint, sgf2n>::Processor(int thread_num,Player& P,
       get_parameterized_filename(P.my_num(), thread_num,
           PREP_DIR "Binary-Output"), ios_base::out);
 
-  open_input_file(P.my_num(), thread_num, machine.opts.cmd_private_input_file);
+  open_input_file(P.my_num(), thread_num, machine.opts.cmd_private_input_file, machine.use_dots);
 
   secure_prng.ReSeed();
   shared_prng.SeedGlobally(P, false);

--- a/Processor/Processor.hpp
+++ b/Processor/Processor.hpp
@@ -83,7 +83,7 @@ Processor<sint, sgf2n>::Processor(int thread_num,Player& P,
   secure_prng.ReSeed();
   shared_prng.SeedGlobally(P, false);
 
-  setup_redirection(P.my_num(), thread_num, opts, out);
+  setup_redirection(P.my_num(), thread_num, opts, machine.use_dots, out);
   Procb.out = out;
 }
 

--- a/Processor/ProcessorBase.cpp
+++ b/Processor/ProcessorBase.cpp
@@ -17,13 +17,17 @@ string ProcessorBase::get_parameterized_filename(int my_num, int thread_num, con
 }
 
 void ProcessorBase::open_input_file(int my_num, int thread_num,
-        const string& prefix)
+        const string& prefix, bool use_dots)
 {
-    string tmp = prefix;
-    if (prefix.empty())
-        tmp = "Player-Data/Input";
+    if (use_dots) {
+        open_dots_file(thread_num);
+    } else {
+        string tmp = prefix;
+        if (prefix.empty())
+            tmp = "Player-Data/Input";
 
-    open_input_file(get_parameterized_filename(my_num, thread_num, tmp));
+        open_input_file(get_parameterized_filename(my_num, thread_num, tmp));
+    }
 }
 
 void ProcessorBase::setup_redirection(int my_num, int thread_num,

--- a/Processor/ProcessorBase.h
+++ b/Processor/ProcessorBase.h
@@ -37,7 +37,8 @@ protected:
 public:
   ExecutionStats stats;
 
-  ofstream stdout_redirect_file;
+  unique_ptr<ostream> output_file;
+  unique_ptr<__gnu_cxx::stdio_filebuf<char>> output_fdbuf;
 
   ProcessorBase();
 
@@ -64,7 +65,7 @@ public:
   T get_input(istream& is, const string& input_filename, const int* params);
 
   void setup_redirection(int my_nu, int thread_num, OnlineOptions& opts,
-      SwitchableOutput& out);
+          bool use_dots, SwitchableOutput& out);
 };
 
 #endif /* PROCESSOR_PROCESSORBASE_H_ */

--- a/Processor/ProcessorBase.h
+++ b/Processor/ProcessorBase.h
@@ -9,6 +9,8 @@
 #include <stack>
 #include <string>
 #include <fstream>
+#include <memory>
+#include <ext/stdio_filebuf.h>
 using namespace std;
 
 #include "Tools/ExecutionStats.h"
@@ -20,7 +22,8 @@ class ProcessorBase
   // Stack
   stack<long> stacki;
 
-  ifstream input_file;
+  unique_ptr<istream> input_file;
+  unique_ptr<__gnu_cxx::stdio_filebuf<char>> input_fdbuf;
   string input_filename;
   size_t input_counter;
 
@@ -52,7 +55,8 @@ public:
     }
 
   void open_input_file(const string& name);
-  void open_input_file(int my_num, int thread_num, const string& prefix="");
+  void open_dots_file(int thread_num);
+  void open_input_file(int my_num, int thread_num, const string& prefix="", bool use_dots = false);
 
   template<class T>
   T get_input(bool interactive, const int* params);

--- a/Tools/Coordinator.cpp
+++ b/Tools/Coordinator.cpp
@@ -13,8 +13,8 @@ void* Coordinator::run_thread(void* coordinator)
     return 0;
 }
 
-Coordinator::Coordinator(const Names& N, string type_name) :
-        P(N, "coordinate-" + type_name), waited(0)
+Coordinator::Coordinator(const Names& N __attribute__((unused)), string type_name __attribute__((unused))) :
+        P(), waited(0)
 {
     pthread_create(&thread, 0, run_thread, this);
 }

--- a/Tools/Coordinator.cpp
+++ b/Tools/Coordinator.cpp
@@ -13,8 +13,8 @@ void* Coordinator::run_thread(void* coordinator)
     return 0;
 }
 
-Coordinator::Coordinator(const Names& N __attribute__((unused)), string type_name __attribute__((unused))) :
-        P(), waited(0)
+Coordinator::Coordinator(const Names& N __attribute__((unused)), string type_name) :
+        P("coordinate-" + type_name), waited(0)
 {
     pthread_create(&thread, 0, run_thread, this);
 }

--- a/Tools/Coordinator.h
+++ b/Tools/Coordinator.h
@@ -6,13 +6,13 @@
 #ifndef TOOLS_COORDINATOR_H_
 #define TOOLS_COORDINATOR_H_
 
-#include "Networking/Player.h"
+#include "Networking/DotsPlayer.h"
 #include "Signal.h"
 #include "Lock.h"
 
 class Coordinator
 {
-    PlainPlayer P;
+    DotsPlayer P;
 
     WaitQueue<string> in;
 

--- a/Tools/SwitchableOutput.h
+++ b/Tools/SwitchableOutput.h
@@ -32,7 +32,7 @@ public:
             out = 0;
     }
 
-    void redirect_to_file(ofstream& out_file)
+    void redirect_to_file(ostream& out_file)
     {
         out = &out_file;
     }


### PR DESCRIPTION
This PR adds functionality to use MP-SPDZ as the underlying communication and I/O layer. This also happens to use [dtrust-project/MP-SPDZ](https://github.com/dtrust-project/libdots) as the underlying DoTS functionality wrapper, which I wrote separately. (Almost) All functionality is enabled by passing the `--dots` flag the SPDZ program.

- MP-SPDZ is (mostly) structured to use a `Player` class that handles all communication functionality, and we extend that class into the `DotsPlayer` to use communication. There are several cases where we had to replace a hard-coded MP-SPDZ `PlainPlayer` (which uses plaintext TCP sockets) with `DotsPlayer`, so **this repo is no longer backwards-compatible with the original MP-SPDZ** repos (i.e. you can’t run the programs using the regular networking anymore).
- We’ve also replaced the input/output functionality to use the file descriptors passed by dots. This mostly required modifications to `ProcessorBase`.