### PR TITLE
Fix bug: exchange in Direct_MAC_Check will fail if octetStream is not aligned

### DIFF
--- a/Protocols/MAC_Check.hpp
+++ b/Protocols/MAC_Check.hpp
@@ -376,6 +376,7 @@ void Direct_MAC_Check<T>::pre_exchange(const Player& P)
 
   for (auto& x : this->values)
     x.pack(oss[P.my_num()]);
+  oss[P.my_num()].append(0);
 }
 
 


### PR DESCRIPTION
I tried to change the `MAC_Check` in `TinierShare.h` from `MAC_Check_` to `Direct_MAC_Check` for some experiments, but it failed with the error:
```
./Tools/octetStream.h:101: octet *octetStream::get_data() const: Assertion `bits[0].n == 0' failed.
```

This was because `Direct_MAC_Check` didn't consume the bit buffer of the octet stream before exchanging, making it fail to `get_data` that assumes the buffer is consumed.

The PR is a simple fix of this problem.