### PR TITLE
add absolute value to precision check

### DIFF
--- a/Compiler/mpc_math.py
+++ b/Compiler/mpc_math.py
@@ -133,7 +133,7 @@ def p_eval(p_c, x):
     if isinstance(x, types._fix):
         # ignore coefficients smaller than precision
         for c in reversed(p_c):
-            if c < 2 ** -(x.f + 1):
+            if abs(c) < 2 ** -(x.f + 1):
                 degree -= 1
             else:
                 break


### PR DESCRIPTION
Current implementation of `p_eval` in `mpc_math` will ignore valid negative coefficients corresponding to the highest degree term.

**Example**
p_c $:= [3, 9, -2]$ corresponds to $$-2x^2 + 9x + 3$$
but turns into $$9x + 3$$ since the coefficient $-2 < 2^{-f}$.

I believe the fix is to simply check the absolute value of the coefficient.