### PR TITLE
Fix variable 't' initialization issue in Math/Zp_Data.h

### DIFF
--- a/Math/Zp_Data.h
+++ b/Math/Zp_Data.h
@@ -73,7 +73,7 @@ class Zp_Data
   Zp_Data() :
       montgomery(0), pi(0), mask(0), pr_byte_length(0), pr_bit_length(0)
   {
-    t = -1;
+    t = MAX_MOD_SZ;
     overhang = 0;
     shanks_r = 0;
   }


### PR DESCRIPTION
The variable 't' in Math/Zp_Data.h was incorrectly initialized, causing issues when running various protocols. This commit addresses the problem by correctly initializing 't' on line 76.

Fixes: #1180