### PR TITLE
Update instruction.rts to include sec parameter

### DIFF
--- a/doc/instructions.rst
+++ b/doc/instructions.rst
@@ -25,7 +25,7 @@ The schedule file is as follows in ASCII text::
   <compilation command line>
   <domain requirements>
   opts: <potential optimizations>
-  sec: <security parameter>
+  sec:<security parameter>
 
 Domain requirements and potential optimizations are related to
 :ref:`nonlinear`. Domain requirements is one of the following:
@@ -56,7 +56,7 @@ schedule file::
   ./compile.py tutorial
   lgp:106
   opts: edabit trunc_pr split
-  sec: 40
+  sec:40
 
 This says that program has only one thread running one bytecode file,
 which is stored in ``tutorial-0.bc`` and has 19444 instructions. It

--- a/doc/instructions.rst
+++ b/doc/instructions.rst
@@ -25,6 +25,7 @@ The schedule file is as follows in ASCII text::
   <compilation command line>
   <domain requirements>
   opts: <potential optimizations>
+  sec: <security parameter>
 
 Domain requirements and potential optimizations are related to
 :ref:`nonlinear`. Domain requirements is one of the following:
@@ -55,6 +56,7 @@ schedule file::
   ./compile.py tutorial
   lgp:106
   opts: edabit trunc_pr split
+  sec: 40
 
 This says that program has only one thread running one bytecode file,
 which is stored in ``tutorial-0.bc`` and has 19444 instructions. It


### PR DESCRIPTION
Since commit cf4426fdb3d8800f058ae50f770db3479f9bf4a4 the security parameter is written and read, in [doc/journey.rts](https://github.com/data61/MP-SPDZ/blob/master/doc/journey.rst) this change is visible, but in the file [doc/instructions.rst)](https://github.com/data61/MP-SPDZ/blob/master/doc/instructions.rst) ithe sec parameter is not documented.
