### PR TITLE
Docker issue causing PLAYERS=0 has been fixed.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -80,8 +80,8 @@ RUN echo "CXX = ${cxx}" >> CONFIG.mine \
         && echo "PREP_DIR = '-DPREP_DIR=\"${prep_dir}/\"'" >> CONFIG.mine \
         && echo "SSL_DIR = '-DSSL_DIR=\"${ssl_dir}/\"'" >> CONFIG.mine
 
-# ssl keys
-ARG cryptoplayers=0
+# ssl keys 
+ARG cryptoplayers=3 
 ENV PLAYERS ${cryptoplayers}
 RUN ./Scripts/setup-ssl.sh ${cryptoplayers} ${ssl_dir}
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ can speed up the last step by running `make -j8 mascot-party.x` beforehand.
 Build a docker image for `mascot-party.x`:
 
 ```
-docker build --tag mpspdz:mascot-party --build-arg machine=mascot-party.x .
+docker build --tag mpspdz:mascot-party --build-arg src=tutorial --build-arg machine=mascot-party.x .
 ```
 
 Run the [the tutorial](Programs/Source/tutorial.mpc):


### PR DESCRIPTION
The current Docker installation instructions are not working properlly. The problem lies in the Dockerfile, where the `ARG cryptoplayers=0` by default. This renders the application unusable unless manually specified through a build argument (`--build-arg cryptoplayers=3`). To avoid this confusion, I propose two changes:

First, let's adjust the `cryptoplayers` default value in the Dockerfile to 3. This simple tweak would make the image run out of the box, saving newcomers the hassle of digging through configurations. Second, `src="tutorial"` needs to be added to build command in the README otherwrise the run command doesn't work properly.