### PR TITLE
convert big endian to little endian

### DIFF
--- a/ECDSA/sign.hpp
+++ b/ECDSA/sign.hpp
@@ -43,6 +43,10 @@ inline P256Element::Scalar hash_to_scalar(const unsigned char* message, size_t l
     P256Element::Scalar res;
     assert(res.size() == crypto_hash_sha256_BYTES);
     crypto_hash_sha256((unsigned char*) res.get_ptr(), message, length);
+    size_t size = crypto_hash_sha256_BYTES;
+    for(size_t i = 0; i < size / 2; i++) {
+        swap(ptr[i], ptr[size - 1 - i]);
+    }
     res.zero_overhang();
     return res;
 }


### PR DESCRIPTION
There is an endianness problem in `sign.hpp`. The `mp_limb_t` takes little endian as input while the program are feeding the `mp_limb_t`  with `big endian`, which causes the sha256 output is not the `ECDSA` message hash.