### PR TITLE
Calculate Conv2D Output Shape in Accordance with PyTorch Docs

### DIFF
--- a/Compiler/ml.py
+++ b/Compiler/ml.py
@@ -2967,11 +2967,11 @@ def apply_padding(input_shape, kernel_size, strides, padding):
     if isinstance(padding, int):
         padding = [padding, padding]
     if isinstance(padding, (tuple, list)):
-        input_shape = [x + sum(padding) for x in input_shape]
+        input_shape = [input_shape[i] + 2*padding[i] for i in range(len(input_shape))]
         padding = 'valid'
     if padding.lower() == 'valid':
-        res = (input_shape[0] - kernel_size[0] + 1) // strides[0], \
-            (input_shape[1] - kernel_size[1] + 1) // strides[1],
+        res = (input_shape[0] - kernel_size[0]) // strides[0] + 1, \
+            (input_shape[1] - kernel_size[1]) // strides[1] + 1,
         assert min(res) > 0, (input_shape, kernel_size, strides, padding)
         return res
     elif padding.lower() == 'same':


### PR DESCRIPTION
This pull request resolves the issue described in #1403 by calculating the output shape of convolutions in accordance with PyTorch documentation (https://pytorch.org/docs/stable/generated/torch.nn.Conv2d.html).

The changes in this pull request have been manually verified to change the inequality in the test program, included in the linked issue, from 'not equal' to 'equal'.

