### PR TITLE
Adding libboost-iostreams-dev to the required packages on Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ parties and malicious security.
 On Linux, this requires a working toolchain and [all
 requirements](#requirements). On Ubuntu, the following might suffice:
 ```
-sudo apt-get install automake build-essential clang cmake git libboost-dev libboost-thread-dev libgmp-dev libntl-dev libsodium-dev libssl-dev libtool python3
+sudo apt-get install automake build-essential clang cmake git libboost-dev libboost-iostreams-dev libboost-thread-dev libgmp-dev libntl-dev libsodium-dev libssl-dev libtool python3
 ```
 On MacOS, this requires [brew](https://brew.sh) to be installed,
 which will be used for all dependencies.


### PR DESCRIPTION
In an Intel CPU x86_64 environment, `libboost-iostreams-dev` was needed to use MP-SPDZ on Ubuntu 22.04 in addition to the list of packagess mentioned in the [TL;DR (Source Distribution)](https://github.com/data61/MP-SPDZ?tab=readme-ov-file#tldr-source-distribution) section of the README.md.

This updates the README.md file to reflect above.