### PR TITLE
Make matmulsm mergeable (Fixes #1407)

### DIFF
--- a/Compiler/allocator.py
+++ b/Compiler/allocator.py
@@ -585,7 +585,7 @@ class Merger:
                 if options.preserve_mem_order:
                     strict_mem_access(n, last_mem_read, last_mem_write)
                 else:
-                    if instr.indices_values:
+                    if instr.indices_values is not None and instr.first_factor_base_addresses is not None and instr.second_factor_base_addresses is not None:
                         # Determine which values get accessed by the MATMULSM instruction and only add the according dependencies.
                         for matmul_idx in range(len(instr.first_factor_base_addresses)):
                             first_base = instr.first_factor_base_addresses[matmul_idx]

--- a/Compiler/instructions.py
+++ b/Compiler/instructions.py
@@ -2504,14 +2504,10 @@ class matmulsm(matmul_base, base.Mergeable):
     arg_format = itertools.cycle(['sw','ci','ci','int','int','int','ci','ci','ci','ci',
                                   'int','int'])
 
-    first_factor_base_addresses: list[int] | None
-    second_factor_base_addresses: list[int] | None
-    indices_values: list[list[int]] | None
-
     def __init__(self, *args,
-                 first_factor_base_addresses: list[int] | None = None,
-                 second_factor_base_addresses: list[int] | None = None,
-                 indices_values: list[int] | None = None,
+                 first_factor_base_addresses=None,
+                 second_factor_base_addresses=None,
+                 indices_values=None,
                  **kwargs):
         matmul_base.__init__(self, *args, **kwargs)
         for matmul_index in range(len(args) // 12):
@@ -2525,8 +2521,10 @@ class matmulsm(matmul_base, base.Mergeable):
         self.second_factor_base_addresses = second_factor_base_addresses
         self.indices_values = indices_values
 
-        assert len(first_factor_base_addresses) == len(second_factor_base_addresses)
-        assert len(indices_values) == 4 * len(first_factor_base_addresses)
+        if first_factor_base_addresses is not None:
+            assert len(first_factor_base_addresses) == len(second_factor_base_addresses)
+            if indices_values is not None:
+                assert len(indices_values) == 4 * len(first_factor_base_addresses)
 
     def add_usage(self, req_node):
         super(matmulsm, self).add_usage(req_node)

--- a/Compiler/instructions.py
+++ b/Compiler/instructions.py
@@ -2484,7 +2484,7 @@ class matmuls(matmul_base, base.Mergeable):
         return sum(reduce(operator.mul, self.args[i + 3:i + 6])
                    for i in range(0, len(self.args), 6))
 
-class matmulsm(matmul_base):
+class matmulsm(matmul_base, base.Mergeable):
     """ Secret matrix multiplication reading directly from memory.
 
     :param: result (sint vector in row-first order)
@@ -2494,26 +2494,48 @@ class matmulsm(matmul_base):
     :param: number of columns in first factor and rows in second factor (int)
     :param: number of columns in second factor and result (int)
     :param: rows of first factor to use (regint vector, length as number of rows in first factor)
-    :param: columns of first factor to use (regint vector, length below)
-    :param: rows of second factor to use (regint vector, length below)
-    :param: columns of second factor to use (regint vector, length below)
-    :param: number of columns of first / rows of second factor to use (int)
-    :param: number of columns of second factor to use (int)
+    :param: columns of first factor to use (regint vector, length as number of columns in the first factor)
+    :param: rows of second factor to use (regint vector, length as number of columns in the first factor)
+    :param: columns of second factor to use (regint vector, length as number of columns in the second factor)
+    :param: total number of columns in the first factor, equal to used number of columns when all columns are used (int)
+    :param: total number of columns in the second factor, equal to used number of columns when all columns are used (int)
     """
     code = base.opcodes['MATMULSM']
-    arg_format = ['sw','ci','ci','int','int','int','ci','ci','ci','ci',
-                  'int','int']
+    arg_format = itertools.cycle(['sw','ci','ci','int','int','int','ci','ci','ci','ci',
+                                  'int','int'])
 
-    def __init__(self, *args, **kwargs):
+    first_factor_base_addresses: list[int] | None
+    second_factor_base_addresses: list[int] | None
+    indices_values: list[list[int]] | None
+
+    def __init__(self, *args,
+                 first_factor_base_addresses: list[int] | None = None,
+                 second_factor_base_addresses: list[int] | None = None,
+                 indices_values: list[int] | None = None,
+                 **kwargs):
         matmul_base.__init__(self, *args, **kwargs)
-        for i in range(2):
-            assert args[6 + i].size == args[3 + i]
-        for i in range(2):
-            assert args[8 + i].size == args[4 + i]
+        for matmul_index in range(len(args) // 12):
+            for i in range(2):
+                assert args[12 * matmul_index + 6 + i].size == args[12 * matmul_index + 3 + i]
+            for i in range(2):
+                assert args[12 * matmul_index + 8 + i].size == args[12 * matmul_index + 4 + i]
+
+        # These are used to reconstruct that accessed memory addresses in the allocator.
+        self.first_factor_base_addresses = first_factor_base_addresses
+        self.second_factor_base_addresses = second_factor_base_addresses
+        self.indices_values = indices_values
+
+        assert len(first_factor_base_addresses) == len(second_factor_base_addresses)
+        assert len(indices_values) == 4 * len(first_factor_base_addresses)
 
     def add_usage(self, req_node):
         super(matmulsm, self).add_usage(req_node)
-        req_node.increment(('matmul', tuple(self.args[3:6])), 1)
+        for i in range(0, len(self.args), 12):
+            req_node.increment(('matmul', (self.args[i + 3], self.args[i + 4], self.args[i + 5])), 1)
+
+    def get_repeat(self):
+        return sum(reduce(operator.mul, self.args[i + 3:i + 6])
+                   for i in range(0, len(self.args), 12))
 
 class conv2ds(base.DataInstruction, base.VarArgsInstruction, base.Mergeable):
     """ Secret 2D convolution.

--- a/Compiler/types.py
+++ b/Compiler/types.py
@@ -2668,12 +2668,16 @@ class sint(_secret, _int):
         self._store_in_mem(address, stms, stmsi)
 
     @classmethod
-    def direct_matrix_mul(cls, A, B, n, m, l, reduce=None, indices=None):
+    def direct_matrix_mul(cls, A, B, n, m, l, reduce=None, indices=None, indices_values=None):
         if indices is None:
             indices = [regint.inc(i) for i in (n, m, m, l)]
+            indices_values = [list(range(i)) for i in (n, m, m, l)]
         res = cls(size=indices[0].size * indices[3].size)
         matmulsm(res, regint(A), regint(B), len(indices[0]), len(indices[1]),
-                 len(indices[3]), *(list(indices) + [m, l]))
+                 len(indices[3]), *(list(indices) + [m, l]),
+                 first_factor_base_addresses=[A],
+                 second_factor_base_addresses=[B],
+                 indices_values=indices_values)
         return res
 
     @vectorize_init

--- a/Compiler/types.py
+++ b/Compiler/types.py
@@ -2673,10 +2673,18 @@ class sint(_secret, _int):
             indices = [regint.inc(i) for i in (n, m, m, l)]
             indices_values = [list(range(i)) for i in (n, m, m, l)]
         res = cls(size=indices[0].size * indices[3].size)
+
+        if isinstance(A, int) and isinstance(B, int):
+            first_factor_base_addresses = [A]
+            second_factor_base_addresses = [B]
+        else:
+            first_factor_base_addresses = None
+            second_factor_base_addresses = None
+
         matmulsm(res, regint(A), regint(B), len(indices[0]), len(indices[1]),
                  len(indices[3]), *(list(indices) + [m, l]),
-                 first_factor_base_addresses=[A],
-                 second_factor_base_addresses=[B],
+                 first_factor_base_addresses=first_factor_base_addresses,
+                 second_factor_base_addresses=second_factor_base_addresses,
                  indices_values=indices_values)
         return res
 

--- a/Processor/Instruction.hpp
+++ b/Processor/Instruction.hpp
@@ -323,8 +323,8 @@ void BaseInstruction::parse_operands(istream& s, int pos, int file_pos)
         get_vector(num_var_args, start, s);
         break;
       case MATMULSM:
-        get_ints(r, s, 3);
-        get_vector(9, start, s);
+        num_var_args = get_int(s);
+        get_vector(num_var_args, start, s);
         break;
 
       // read from file, input is opcode num_args, 
@@ -1117,8 +1117,7 @@ inline void Instruction::execute(Processor<sint, sgf2n>& Proc) const
         Proc.Procp.matmuls(Proc.Procp.get_S(), *this);
         return;
       case MATMULSM:
-        Proc.Procp.protocol.matmulsm(Proc.Procp, Proc.machine.Mp.MS, *this,
-            Proc.read_Ci(r[1]), Proc.read_Ci(r[2]));
+        Proc.Procp.protocol.matmulsm(Proc.Procp, Proc.machine.Mp.MS, *this);
         return;
       case CONV2DS:
         Proc.Procp.protocol.conv2ds(Proc.Procp, *this);

--- a/Processor/Processor.h
+++ b/Processor/Processor.h
@@ -77,8 +77,12 @@ public:
   void mulrs(const vector<int>& reg);
   void dotprods(const vector<int>& reg, int size);
   void matmuls(const vector<T>& source, const Instruction& instruction);
-  void matmulsm(const MemoryPart<T>& source, const Instruction& instruction, size_t a,
-      size_t b);
+  void matmulsm(const MemoryPart<T>& source, const Instruction& instruction);
+
+  void matmulsm_finalize_batch(vector<int>::const_iterator startMatmul, int startI, int startJ,
+                               vector<int>::const_iterator endMatmul,
+                               int endI, int endJ);
+
   void conv2ds(const Instruction& instruction);
 
   void secure_shuffle(const Instruction& instruction);

--- a/Programs/Source/test_dot.mpc
+++ b/Programs/Source/test_dot.mpc
@@ -1,0 +1,147 @@
+a = Array.create_from([sint(1), sint(2), sint(3), sint(4)])
+b = Array.create_from([sint(3), sint(2), sint(1)])
+
+c = Matrix.create_from([
+    [sint(1), sint(2), sint(3)],
+    [sint(4), sint(5), sint(6)],
+    [sint(7), sint(8), sint(9)],
+    [sint(10), sint(11), sint(12)]
+])
+
+d = Matrix.create_from([
+    [sint(12), sint(11), sint(10), sint(9)],
+    [sint(8), sint(7), sint(6), sint(5)],
+    [sint(4), sint(3), sint(2), sint(1)]
+])
+
+
+def test_array(expected: list[int], actual: Array) -> None:
+    actual = actual.reveal()
+    expected = Array.create_from([cint(x) for x in expected])
+    @for_range(len(expected))
+    def _(i: cint) -> None:
+        @if_(actual[i] != expected[i])
+        def fail():
+            print_ln("Unexpected entry at index %s", i)
+            print_ln("Expected:")
+            expected.print_reveal_nested()
+            print_ln("Actual:")
+            actual.print_reveal_nested()
+
+            crash()
+
+
+def test_matrix(expected: list[list[int]], actual: Matrix) -> None:
+    actual = actual.reveal()
+    expected = Matrix.create_from([[cint(x) for x in row] for row in expected])
+    @for_range(len(expected))
+    def outer(i: cint) -> None:
+
+        @for_range(len(expected[0]))
+        def inner(j: cint) -> None:
+            @if_(actual[i][j] != expected[i][j])
+            def fail():
+                print_ln("Unexpected entry at index %s,%s", i, j)
+                print_ln("Expected:")
+                expected.print_reveal_nested()
+                print_ln("Actual:")
+                actual.print_reveal_nested()
+
+                crash()
+
+break_point()
+def hacky_array_dot_matrix(arr: Array, mat: Matrix) -> Array:
+    # Arrays sadly do not have a dot function, therefore the array is converted into a 1 times n Matrix by copying memory addresses.
+    tmp = sint.Matrix(rows=1, columns=len(arr), address=arr.address)
+    result = tmp.dot(mat)
+    return sint.Array(mat.shape[1], result.address)
+
+start_timer(3)
+
+e3 = hacky_array_dot_matrix(a, c)
+# b[0] = e3[0]
+f3 = hacky_array_dot_matrix(b, d)
+
+stop_timer(3)
+
+e3 = e3.reveal()
+f3 = f3.reveal()
+
+e3.print_reveal_nested()
+f3.print_reveal_nested()
+
+test_array([70, 80, 90], e3)
+test_array([56, 50, 44, 38], f3)
+
+start_timer(4)
+
+e4 = hacky_array_dot_matrix(a, c)
+b[-1] = e4[0]
+f4 = hacky_array_dot_matrix(b, d)
+
+stop_timer(4)
+
+test_array([70, 80, 90], e4)
+test_array([332, 257, 182, 107], f4)
+
+f4.print_reveal_nested()
+
+# TODO: Crashes
+
+
+start_timer(5)
+g = c.dot(d)
+stop_timer(5)
+
+test_matrix([
+    [ 40,  34,  28,  22],
+    [112,  97,  82,  67],
+    [184, 160, 136, 112],
+    [256, 223, 190, 157]
+], g)
+g.print_reveal_nested()
+
+
+# Big matrix tests.
+# These are intended to test matrix multiplications that require multiple batches.
+
+def identity(size: int) -> Matrix:
+    result = sint.Matrix(rows=size, columns=size)
+    result.assign_all(0)
+    for i in range(size):
+        result[i][i] = 1
+    return result
+
+
+def counting_matrix(rows: int, columns: int) -> Matrix:
+    result = sint.Matrix(rows, columns)
+    @for_range(rows)
+    def outer(i: cint) -> None:
+        @for_range(columns)
+        def inner(j: cint) -> None:
+            result[i][j] = i * columns + j
+    return result
+
+
+def clear_counting_matrix(rows: int, columns: int) -> list[list[int]]:
+    return [list(range(i * columns, (i + 1) * columns)) for i in range(rows)]
+
+
+# Single matrix multiplication requiring multiple batches.
+a = counting_matrix(20, 20)
+b = identity(20)
+
+start_timer(6)
+c = a * b
+stop_timer(6)
+
+test_matrix(clear_counting_matrix(20, 20), c)
+
+# Multiple matrix multiplications requiring multiple batches.
+start_timer(7)
+d = a * b
+e = c * b
+stop_timer(7)
+
+test_matrix(clear_counting_matrix(20, 20), d)
+test_matrix(clear_counting_matrix(20, 20), e)

--- a/Programs/Source/test_dot.mpc
+++ b/Programs/Source/test_dot.mpc
@@ -15,11 +15,11 @@ d = Matrix.create_from([
 ])
 
 
-def test_array(expected: list[int], actual: Array) -> None:
+def test_array(expected, actual):
     actual = actual.reveal()
     expected = Array.create_from([cint(x) for x in expected])
     @for_range(len(expected))
-    def _(i: cint) -> None:
+    def _(i):
         @if_(actual[i] != expected[i])
         def fail():
             print_ln("Unexpected entry at index %s", i)
@@ -31,14 +31,14 @@ def test_array(expected: list[int], actual: Array) -> None:
             crash()
 
 
-def test_matrix(expected: list[list[int]], actual: Matrix) -> None:
+def test_matrix(expected, actual):
     actual = actual.reveal()
     expected = Matrix.create_from([[cint(x) for x in row] for row in expected])
     @for_range(len(expected))
-    def outer(i: cint) -> None:
+    def outer(i):
 
         @for_range(len(expected[0]))
-        def inner(j: cint) -> None:
+        def inner(j):
             @if_(actual[i][j] != expected[i][j])
             def fail():
                 print_ln("Unexpected entry at index %s,%s", i, j)
@@ -50,7 +50,7 @@ def test_matrix(expected: list[list[int]], actual: Matrix) -> None:
                 crash()
 
 break_point()
-def hacky_array_dot_matrix(arr: Array, mat: Matrix) -> Array:
+def hacky_array_dot_matrix(arr, mat):
     # Arrays sadly do not have a dot function, therefore the array is converted into a 1 times n Matrix by copying memory addresses.
     tmp = sint.Matrix(rows=1, columns=len(arr), address=arr.address)
     result = tmp.dot(mat)
@@ -105,7 +105,7 @@ g.print_reveal_nested()
 # Big matrix tests.
 # These are intended to test matrix multiplications that require multiple batches.
 
-def identity(size: int) -> Matrix:
+def identity(size):
     result = sint.Matrix(rows=size, columns=size)
     result.assign_all(0)
     for i in range(size):
@@ -113,17 +113,17 @@ def identity(size: int) -> Matrix:
     return result
 
 
-def counting_matrix(rows: int, columns: int) -> Matrix:
+def counting_matrix(rows, columns):
     result = sint.Matrix(rows, columns)
     @for_range(rows)
-    def outer(i: cint) -> None:
+    def outer(i):
         @for_range(columns)
-        def inner(j: cint) -> None:
+        def inner(j):
             result[i][j] = i * columns + j
     return result
 
 
-def clear_counting_matrix(rows: int, columns: int) -> list[list[int]]:
+def clear_counting_matrix(rows, columns):
     return [list(range(i * columns, (i + 1) * columns)) for i in range(rows)]
 
 
@@ -145,3 +145,16 @@ stop_timer(7)
 
 test_matrix(clear_counting_matrix(20, 20), d)
 test_matrix(clear_counting_matrix(20, 20), e)
+
+
+start_timer(8)
+d = a.dot(b, n_threads=2)
+stop_timer(8)
+
+test_matrix(clear_counting_matrix(20, 20), d)
+
+start_timer(9)
+M = sint.Matrix(10, 10)
+M.direct_mul(M, indices=[regint(0), regint.inc(10), regint.inc(10),
+                         regint(0)])
+stop_timer(9)

--- a/Programs/Source/test_dot.mpc
+++ b/Programs/Source/test_dot.mpc
@@ -158,3 +158,8 @@ M = sint.Matrix(10, 10)
 M.direct_mul(M, indices=[regint(0), regint.inc(10), regint.inc(10),
                          regint(0)])
 stop_timer(9)
+
+
+start_timer(10)
+sint.Matrix(1000, 1000) * sint.Matrix(1000, 1000)
+stop_timer(10)

--- a/Protocols/Hemi.h
+++ b/Protocols/Hemi.h
@@ -34,7 +34,7 @@ public:
             SubProcessor<T>& processor);
 
     void matmulsm(SubProcessor<T>& processor, MemoryPart<T>& source,
-            const Instruction& instruction, int a, int b);
+            const Instruction& instruction);
     void conv2ds(SubProcessor<T>& processor, const Instruction& instruction);
 };
 

--- a/Protocols/Replicated.h
+++ b/Protocols/Replicated.h
@@ -111,8 +111,8 @@ public:
 
     template<int = 0>
     void matmulsm(SubProcessor<T> & proc, MemoryPart<T>& source,
-            const Instruction& instruction, int a, int b)
-    { proc.matmulsm(source, instruction, a, b); }
+            const Instruction& instruction)
+    { proc.matmulsm(source, instruction); }
 
     template<int = 0>
     void conv2ds(SubProcessor<T>& proc, const Instruction& instruction)


### PR DESCRIPTION
As promised in #1407 I spent some time on making MATMULSM mergeable.
For most protocols, the new implementation will merge as much communication as possible while respecting the batch size.

In order for the allocator to be able to determine the memory addresses accessed by a MATMUSLM, I needed to add some temporary fields to the instruction that contain the used rows and columns. This is somewhat hacky, but it's the cleanest solution I found.
If those fields are not present, the allocator will fall back to the previous logic where the instructions is made to be dependent of all previous memory writes.

Further, the Hemi protocol's implementation will correctly calculate the matrix products, but will do so sequentially as that would require to somehow merge the communication of multiple matrix preps.