### PR TITLE
tidy output for remote execution

### DIFF
--- a/Compiler/compilerLib.py
+++ b/Compiler/compilerLib.py
@@ -240,13 +240,6 @@ class Compiler:
             dest="verbose",
             help="more verbose output",
         )
-        parser.add_option(
-            "-t",
-            "--tidy_output",
-            action="store_true",
-            dest="tidy_output",
-            help="output prints tidy and grouped by party (note: it delays outputs)",
-        )
         if self.execute:
             parser.add_option(
                 "-E",
@@ -259,6 +252,13 @@ class Compiler:
                 "--hostfile",
                 dest="hostfile",
                 help="hosts to execute with",
+            )
+            parser.add_option(
+                "-t",
+                "--tidy_output",
+                action="store_true",
+                dest="tidy_output",
+                help="make output prints tidy and grouped by party (note: delays the prints)",
             )
         else:
             parser.add_option(

--- a/README.md
+++ b/README.md
@@ -366,11 +366,14 @@ There are three ways of running computation:
    ```
 
    If <path> does not start with `/` (only one `/` after the
-   hostname), the path with be relative to the home directory of the
+   hostname), the path will be relative to the home directory of the
    user. Otherwise (`//` after the hostname it will be relative to the
    root directory.
 
    It is assumed that the SSH login is possible without password.
+
+   Adding the compiler option `-t` (`--tidy_output`) groups the output prints by
+   party; however, it delays the outputs until the execution is finished.
 
 Even with the integrated execution it is important to keep in mind
 that there are two different phases, the compilation and the run-time


### PR DESCRIPTION
When running remote execution (with the HOSTS file) the output prints of the MPC parties are intertwined. This small change separates the output prints of each party, just because it's easier to read (or run a parser on) a tidy output.