### PR TITLE
Fix: compile error from `floatingpoint.py`

### DIFF
--- a/Compiler/floatingpoint.py
+++ b/Compiler/floatingpoint.py
@@ -54,7 +54,7 @@ def maskField(a, k):
 def EQZ(a, k):
     prog = program.Program.prog
     if prog.use_split():
-        from GC.types import sbitvec
+        from Compiler.GC.types import sbitvec
         v = sbitvec(a, k).v
         bit = util.tree_reduce(operator.and_, (~b for b in v))
         return types.sintbit.conv(bit)


### PR DESCRIPTION
As I was trying to compile my circuit using the `replicated-ring-party` protocol I run into this error

```
a = sinf, k = 63, kappa = None

    @instructions_base.ret_cisc
    def EQZ(a, k, kappa):
        prog = program.Program.prog
        if prog.use_split():
>           from GC.types import sbitvec
E           ModuleNotFoundError: No module named 'GC.types'

MP-SPDZ/Compiler/floatingpoint.py:57: ModuleNotFoundError
```

The PR fixes the error