### PR TITLE
Assign to AVX_SIMPLEOT to properly set -DNO_AVX_OT on Apple Silicon

### DIFF
--- a/CONFIG
+++ b/CONFIG
@@ -48,7 +48,7 @@ ARCH =
 AVX_OT = 0
 endif
 
-AVX_SIMPLEOT = AVX_OT
+AVX_SIMPLEOT := $(AVX_OT)
 
 ifeq ($(OS), Darwin)
 BREW_CFLAGS += -I/usr/local/opt/openssl/include -I`brew --prefix`/opt/openssl/include -I`brew --prefix`/include


### PR DESCRIPTION
Hello,

When trying to build certain binaries (e.g. `make -j cowgear-party.x`), the following error occurs on my Apple Silicon OS X machine:

```
Undefined symbols for architecture arm64:
  "_receiver_keygen", referenced from:
      void BaseOT::exec_base<ot_sender, ot_receiver>(bool) in BaseOT.o
  "_receiver_maketable", referenced from:
      void BaseOT::exec_base<ot_sender, ot_receiver>(bool) in BaseOT.o
  "_receiver_procS", referenced from:
      void BaseOT::exec_base<ot_sender, ot_receiver>(bool) in BaseOT.o
  "_receiver_rsgen", referenced from:
      void BaseOT::exec_base<ot_sender, ot_receiver>(bool) in BaseOT.o
  "_sender_genS", referenced from:
      void BaseOT::exec_base<ot_sender, ot_receiver>(bool) in BaseOT.o
  "_sender_keygen", referenced from:
      void BaseOT::exec_base<ot_sender, ot_receiver>(bool) in BaseOT.o
ld: symbol(s) not found for architecture arm64
```

Since this code has compile-time AVX optimizations, and since this architecture does not support AVX instructions natively, I expected the CONFIG checks to add `-DNO_AVX_OT` to `CFLAGS`, but I did not see it in the make command output.

I think the `AVX_OT` value was maybe not correctly propagated to the `AVX_SIMPLEOT` variable (or the parallel computation caused a timeliness issue), as the proposed change resolves this linker error and adds the expected `-DNO_AVX_OT` to `CFLAGS`.

Please let me know if you have any questions.

Thanks!