### PR TITLE
Fix compilation error on aarch64 by limiting cpuid.h inclusion to x86

### DIFF
--- a/OT/BaseOT.cpp
+++ b/OT/BaseOT.cpp
@@ -9,7 +9,7 @@
 #include <fstream>
 #include <pthread.h>
 
-#ifdef __linux__
+#if defined(__linux__) and defined(__x86_64__)
 #include <cpuid.h>
 #endif
 


### PR DESCRIPTION
This pull request fixes a compilation error that occurred on aarch64 Linux systems due to the inclusion of cpuid.h, which is specific to Intel x86 architecture.

Problem:
The file BaseOT.cpp included cpuid.h when compiled on Linux regardless of the architecture, causing a compile error on aarch64. The cpuid.h header is only valid for x86 (32-bit and 64-bit) systems.

Solution:
I updated the preprocessor directive to check if both __linux__ and __x86_64__ are defined, ensuring that cpuid.h is only included on Linux systems running on x86 architectures.

Why:
The cpuid.h is only used in systems with AVX support, which is specific to Intel x86 processors. The change prevents compilation issues on aarch64 and other non-x86 architectures.