### PR TITLE
fix(typos): correct spelling errors in Compiler Python files

### DIFF
--- a/Compiler/GC/types.py
+++ b/Compiler/GC/types.py
@@ -26,7 +26,7 @@ class _binary:
         return self ^ other ^ (self & other)
     def reveal_to(self, *args, **kwargs):
         raise CompilerError(
-            '%s does not support revealing to indivual players' % type(self))
+            '%s does not support revealing to individual players' % type(self))
 
 class bits(Tape.Register, _structure, _bit, _binary):
     n = 40
@@ -449,7 +449,7 @@ class sbits(bits):
         AND: 1
         NOT: -4
 
-    Instances can be also be initalized from :py:obj:`~Compiler.types.regint`
+    Instances can be also be initialized from :py:obj:`~Compiler.types.regint`
     and :py:obj:`~Compiler.types.sint`.
     """
     max_length = 64

--- a/Compiler/floatingpoint.py
+++ b/Compiler/floatingpoint.py
@@ -84,7 +84,7 @@ def bits(a,m):
     return res
 
 def carry(b, a, compute_p=True):
-    """ Carry propogation:
+    """ Carry propagation:
         (p,g) = (p_2, g_2)o(p_1, g_1) -> (p_1 & p_2, g_2 | (p_2 & g_1))
     """
     if compute_p:
@@ -761,3 +761,4 @@ def BitDecFull(a, n_bits=None, maybe_mixed=False):
         return abits
     else:
         return [sint.conv(bit) for bit in abits]
+


### PR DESCRIPTION
Fixed multiple spelling mistakes in Compiler Python source files:  
- Corrected "indivual" to "individual" in Compiler/GC/types.py.  
- Fixed "initalized" to "initialized" in Compiler/GC/types.py.  
- Corrected "propogation" to "propagation" in Compiler/floatingpoint.py.  
