### PR TITLE
Separate executable for LowGear offline phase

### DIFF
--- a/Machines/lowgear-offline.cpp
+++ b/Machines/lowgear-offline.cpp
@@ -1,0 +1,20 @@
+/*
+ * lowgear-offline.cpp
+ *
+ */
+
+#include "SPDZ.hpp"
+#include "Math/gfp.hpp"
+#include "Protocols/LowGearShare.h"
+#include "Protocols/CowGearOptions.h"
+#include "Protocols/CowGearPrep.hpp"
+#include "Processor/FieldMachine.hpp"
+#include "Processor/OfflineMachine.hpp"
+
+int main(int argc, const char** argv)
+{
+    ez::ezOptionParser opt;
+    CowGearOptions::singleton = CowGearOptions(opt, argc, argv, false);
+    DishonestMajorityFieldMachine<LowGearShare, LowGearShare, gf2n_short,
+            OfflineMachine<DishonestMajorityMachine>>(argc, argv, opt);
+}

--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ CONFIG.mine:
 
 online: Fake-Offline.x Server.x Player-Online.x Check-Offline.x emulate.x mascot-party.x
 
-offline: $(OT_EXE) Check-Offline.x mascot-offline.x cowgear-offline.x mal-shamir-offline.x
+offline: $(OT_EXE) Check-Offline.x mascot-offline.x cowgear-offline.x lowgear-offline.x mal-shamir-offline.x
 
 gen_input: gen_input_f2n.x gen_input_fp.x
 
@@ -283,6 +283,7 @@ l2h-example.x: $(VM) $(OT) Machines/Tinier.o
 he-example.x: $(FHEOFFLINE)
 mascot-offline.x: $(VM) $(TINIER)
 cowgear-offline.x: $(TINIER) $(FHEOFFLINE)
+lowgear-offline.x: $(TINIER) $(FHEOFFLINE) Protocols/CowGearOptions.o Protocols/LowGearKeyGen.o
 semi-offline.x: $(GC_SEMI) $(OT)
 semi2k-offline.x: $(GC_SEMI) $(OT)
 hemi-offline.x: $(GC_SEMI) $(FHEOFFLINE) $(OT)

--- a/README.md
+++ b/README.md
@@ -1201,7 +1201,7 @@ the actual computation. First, compile the binary:
 `make <protocol>-offline.x`
 
 At the time of writing the supported protocols are `mascot`,
-`cowgear`, `mal-shamir`, `semi`, `semi2k`, and `hemi`.
+`cowgear`, `lowgear`, `mal-shamir`, `semi`, `semi2k`, and `hemi`.
 
 If you have not done so already, then compile your high-level program:
 


### PR DESCRIPTION
Hello, @mkskeller .

I believe that this commit adds support for running the offline phase of LowGear protocol separately. I did the minimal changes for it to compile and run. I am not sure that all the parameters work as they should, but the changes seem to be working for our usecase.

Thank you for helping me with this change.