### PR TITLE
Fix quadratic runtime of sint.concat

### DIFF
--- a/Compiler/types.py
+++ b/Compiler/types.py
@@ -3190,7 +3190,10 @@ class sint(_secret, _int):
     def concat(cls, parts):
         parts = list(parts)
         res = cls(size=sum(len(part) for part in parts))
-        args = sum(([len(part), part] for part in parts), [])
+        args = []
+        for part in parts:
+            args.append(len(part))
+            args.append(part)
         concats(res, *args)
         return res
 


### PR DESCRIPTION
`sum(([len(part), part] for part in parts), [])` copies the whole args list `n` times, resulting in very long compile times when concatenating a lot of vectors. This patch simply replaces the sum by a small for loop to fix this :)

Best,
Vincent