### PR TITLE
feat: support runtime length for vectorized functions with compile-time max bound

### DIFF
--- a/Compiler/library.py
+++ b/Compiler/library.py
@@ -24,19 +24,59 @@ def get_block():
     return get_program().curr_block
 
 def vectorize(function):
-    def vectorized_function(*args, **kwargs):
-        if len(args) > 0 and 'size' in dir(args[0]):
-            instructions_base.set_global_vector_size(args[0].size)
-            res = function(*args, **kwargs)
-            instructions_base.reset_global_vector_size()
-        elif 'size' in kwargs:
-            instructions_base.set_global_vector_size(kwargs['size'])
-            del kwargs['size']
-            res = function(*args, **kwargs)
-            instructions_base.reset_global_vector_size()
+    def mask_output(value, active: regint):
+        if value is None:
+            return None
+        if isinstance(value, tuple):
+            return tuple(mask_output(x, active) for x in value)
+        if isinstance(value, list):
+            return [mask_output(x, active) for x in value]
+        
+        try:
+            size = value.size
+        except AttributeError:
+            return value
+        
+        if size == 1:
+            return value
+
+        return value * active
+
+    def get_vector_size(call_args, call_kwargs):
+        if len(call_args) > 0 and 'size' in dir(call_args[0]):
+            return call_args[0].size
+        elif 'size' in call_kwargs:
+            return call_kwargs['size']
         else:
-            res = function(*args, **kwargs)
+            return None
+
+    def vectorized_function(*args, **kwargs):
+        active_vector_size = regint.conv(kwargs.pop('active_length', None))
+
+        size = get_vector_size(args, kwargs)
+        if size is not None:
+            if 'size' in kwargs:
+                del kwargs['size']
+            instructions_base.set_global_vector_size(size)
+
+        set_active_vector_size = active_vector_size is not None and size is not None and size > 1
+        context_saved_arg = None
+        if set_active_vector_size:
+            context_saved_arg = get_arg()
+            starg(-active_vector_size)
+
+        res = function(*args, **kwargs)
+
+        if set_active_vector_size:
+            starg(context_saved_arg)
+            active = regint.inc(size) < active_vector_size
+            res = mask_output(res, active)
+        
+        if size is not None:
+            instructions_base.reset_global_vector_size()
+
         return res
+
     vectorized_function.__name__ = function.__name__
     copy_doc(vectorized_function, function)
     return vectorized_function

--- a/GC/ShareThread.hpp
+++ b/GC/ShareThread.hpp
@@ -167,24 +167,50 @@ template<class T>
 void ShareThread<T>::and_(Processor<T>& processor,
         const vector<int>& args, bool repeat)
 {
+    vector<int> active_args;
+    int active_limit = -1;
+    long prefix = processor.get_arg().get();
+    if (prefix < 0)
+        active_limit = int(-prefix);
+
+    if (active_limit >= 0)
+    {
+        active_args.reserve(args.size());
+        for (auto it = args.begin(); it < args.end(); it += 4)
+        {
+            int active_bits = min(*it, active_limit);
+            if (active_bits > 0)
+            {
+                active_args.push_back(active_bits);
+                active_args.push_back(*(it + 1));
+                active_args.push_back(*(it + 2));
+                active_args.push_back(*(it + 3));
+            }
+        }
+    }
+    else
+    {
+        active_args = args;
+    }
+
     auto& protocol = this->protocol;
     auto& S = processor.S;
-    processor.check_args(args, 4);
+    processor.check_args(active_args, 4);
     protocol->init_mul();
     T x_ext, y_ext;
 
     size_t total_bits = 0;
-    for (auto it = args.begin(); it < args.end(); it += 4)
+    for (auto it = active_args.begin(); it < active_args.end(); it += 4)
         total_bits += *it;
 
     // accept 10 % waste
-    bool fast_mode = 0.1 * total_bits > args.size() / 4 * T::default_length;
+    bool fast_mode = 0.1 * total_bits > active_args.size() / 4 * T::default_length;
     if (fast_mode)
     {
         protocol->set_fast_mode(true);
     }
 
-    ArgList<BitOpTuple<T>> infos(args);
+    ArgList<BitOpTuple<T>> infos(active_args);
 
     if (repeat)
         for (auto info : infos)
@@ -268,11 +294,43 @@ void ShareThread<T>::andrsvec(Processor<T>& processor, const vector<int>& args)
     int N_BITS = T::default_length;
     auto& protocol = this->protocol;
     assert(protocol);
+
+    vector<int> active_args;
+    int active_limit = -1;
+    long prefix = processor.get_arg().get();
+    if (prefix < 0)
+        active_limit = int(-prefix);
+
+    if (active_limit >= 0)
+    {
+        active_args.reserve(args.size());
+        auto it = args.begin();
+        while (it < args.end())
+        {
+            int n_args = (*it - 3) / 2;
+            int size = *(it + 1);
+            int active_size = min(size, active_limit);
+            if (active_size > 0)
+            {
+                int group_size = 2 * n_args + 3;
+                active_args.push_back(*it);
+                active_args.push_back(active_size);
+                for (int i = 0; i < group_size - 2; i++)
+                    active_args.push_back(*(it + 2 + i));
+            }
+            it += 2 * n_args + 3;
+        }
+    }
+    else
+    {
+        active_args = args;
+    }
+
     protocol->init_mul();
-    auto it = args.begin();
+    auto it = active_args.begin();
     T x_ext, y_ext;
     int total_bits = 0;
-    while (it < args.end())
+    while (it < active_args.end())
     {
         int n_args = (*it++ - 3) / 2;
         int size = *it++;
@@ -297,8 +355,8 @@ void ShareThread<T>::andrsvec(Processor<T>& processor, const vector<int>& args)
 
     protocol->exchange();
 
-    it = args.begin();
-    while (it < args.end())
+    it = active_args.begin();
+    while (it < active_args.end())
     {
         int n_args = (*it++ - 3) / 2;
         int size = *it++;

--- a/Processor/Instruction.cpp
+++ b/Processor/Instruction.cpp
@@ -21,10 +21,11 @@ void Instruction::execute_clear_gf2n(StackedVector<cgf2n>& registers,
 {
     auto& C2 = registers;
     auto& M2C = memory;
+    int active_size = get_effective_vector_size(Proc, size);
     switch (opcode)
     {
 #define X(NAME, PRE, CODE) \
-        case NAME: { PRE; for (int i = 0; i < size; i++) { CODE; } } break;
+        case NAME: { PRE; for (int i = 0; i < active_size; i++) { CODE; } } break;
         CLEAR_GF2N_INSTRUCTIONS
 #undef X
     }
@@ -62,10 +63,11 @@ void Instruction::execute_regint(ArithmeticProcessor& Proc, MemoryPart<Integer>&
 {
     (void) Mi;
     auto& Ci = Proc.get_Ci();
+    int active_size = get_effective_vector_size(Proc, size);
     switch (opcode)
     {
 #define X(NAME, PRE, CODE) \
-        case NAME: { PRE; for (int i = 0; i < size; i++) { CODE; } } break;
+        case NAME: { PRE; for (int i = 0; i < active_size; i++) { CODE; } } break;
         REGINT_INSTRUCTIONS
 #undef X
     }
@@ -73,18 +75,20 @@ void Instruction::execute_regint(ArithmeticProcessor& Proc, MemoryPart<Integer>&
 
 void Instruction::shuffle(ArithmeticProcessor& Proc) const
 {
-    for (int i = 0; i < size; i++)
+    int active_size = get_effective_vector_size(Proc, size);
+    for (int i = 0; i < active_size; i++)
         Proc.write_Ci(r[0] + i, Proc.read_Ci(r[1] + i));
-    for (int i = 0; i < size; i++)
+    for (int i = 0; i < active_size; i++)
     {
-        int j = Proc.shared_prng.get_uint(size - i);
+        int j = Proc.shared_prng.get_uint(active_size - i);
         swap(Proc.get_Ci_ref(r[0] + i), Proc.get_Ci_ref(r[0] + i + j));
     }
 }
 
 void Instruction::bitdecint(ArithmeticProcessor& Proc) const
 {
-    for (int j = 0; j < size; j++)
+    int active_size = get_effective_vector_size(Proc, size);
+    for (int j = 0; j < active_size; j++)
     {
         long a = Proc.read_Ci(r[0] + j);
         for (unsigned int i = 0; i < start.size(); i++)

--- a/Processor/Instruction.hpp
+++ b/Processor/Instruction.hpp
@@ -46,6 +46,14 @@ void BaseInstruction::parse(istream& s, int inst_pos)
   parse_operands(s, inst_pos, pos);
 }
 
+inline int get_effective_vector_size(const ProcessorBase& Proc, int size)
+{
+  long prefix = Proc.get_arg().get();
+  if (prefix < 0)
+    return min(size, int(-prefix));
+  return size;
+}
+
 inline
 void BaseInstruction::parse_operands(istream& s, int pos, int file_pos)
 {
@@ -947,14 +955,17 @@ inline void Instruction::execute(Processor<sint, sgf2n>& Proc) const
 {
   auto& Procp = Proc.Procp;
   auto& Proc2 = Proc.Proc2;
+  int active_size = get_effective_vector_size(Proc, size);
+  auto active_inst = *this;
+  active_inst.size = active_size;
 
   // optimize some instructions
   switch (opcode)
   {
     case CONVMODP:
       vector<Integer> values;
-      values.reserve(size);
-      for (int i = 0; i < size; i++)
+      values.reserve(active_size);
+      for (int i = 0; i < active_size; i++)
       {
           auto source = Proc.read_Cp(r[1] + i);
           Integer tmp;
@@ -969,14 +980,14 @@ inline void Instruction::execute(Processor<sint, sgf2n>& Proc) const
       }
       if (r[2])
           Procp.protocol.sync(values, Proc.P);
-      for (int i = 0; i < size; i++)
+      for (int i = 0; i < active_size; i++)
           Proc.write_Ci(r[0] + i, values[i].get());
       return;
   }
 
   int r[3] = {this->r[0], this->r[1], this->r[2]};
   int64_t n = this->n;
-  for (int i = 0; i < size; i++) 
+  for (int i = 0; i < active_size; i++) 
   { switch (opcode)
     {
       case LDMC:
@@ -1143,16 +1154,16 @@ inline void Instruction::execute(Processor<sint, sgf2n>& Proc) const
         Proc.write_Cp(r[0],Proc.temp.ansp);
         break;
       case SHRSI:
-        sint::shrsi(Procp, *this);
+        sint::shrsi(Procp, active_inst);
         return;
       case GSHRSI:
-        sgf2n::shrsi(Proc2, *this);
+        sgf2n::shrsi(Proc2, active_inst);
         return;
       case OPEN:
-        Proc.Procp.POpen(*this);
+        Proc.Procp.POpen(active_inst);
         return;
       case GOPEN:
-        Proc.Proc2.POpen(*this);
+        Proc.Proc2.POpen(active_inst);
         return;
       case MULS:
         Proc.Procp.muls(start);
@@ -1167,48 +1178,48 @@ inline void Instruction::execute(Processor<sint, sgf2n>& Proc) const
         Proc.Proc2.protocol.mulrs(start, Proc.Proc2);
         return;
       case DOTPRODS:
-        Proc.Procp.dotprods(start, size);
+        Proc.Procp.dotprods(start, active_size);
         return;
       case GDOTPRODS:
-        Proc.Proc2.dotprods(start, size);
+        Proc.Proc2.dotprods(start, active_size);
         return;
       case MATMULS:
-        Proc.Procp.matmuls(Proc.Procp.get_S(), *this);
+        Proc.Procp.matmuls(Proc.Procp.get_S(), active_inst);
         return;
       case GMATMULS:
-        Proc.Proc2.matmuls(Proc.Proc2.get_S(), *this);
+        Proc.Proc2.matmuls(Proc.Proc2.get_S(), active_inst);
         return;
       case MATMULSM:
-        Proc.Procp.protocol.matmulsm(Proc.Procp, Proc.machine.Mp.MS, *this);
+        Proc.Procp.protocol.matmulsm(Proc.Procp, Proc.machine.Mp.MS, active_inst);
         return;
       case GMATMULSM:
-        Proc.Proc2.protocol.matmulsm(Proc.Proc2, Proc.machine.M2.MS, *this);
+        Proc.Proc2.protocol.matmulsm(Proc.Proc2, Proc.machine.M2.MS, active_inst);
         return;
       case CONV2DS:
-        Proc.Procp.protocol.conv2ds(Proc.Procp, *this);
+        Proc.Procp.protocol.conv2ds(Proc.Procp, active_inst);
         return;
       case TRUNC_PR:
-        Proc.Procp.protocol.trunc_pr(start, size, Proc.Procp,
+        Proc.Procp.protocol.trunc_pr(start, active_size, Proc.Procp,
             sint::clear::characteristic_two);
         return;
       case SECSHUFFLE:
-        Proc.Procp.secure_shuffle(*this);
+        Proc.Procp.secure_shuffle(active_inst);
         return;
       case GSECSHUFFLE:
-        Proc.Proc2.secure_shuffle(*this);
+        Proc.Proc2.secure_shuffle(active_inst);
         return;
       case GENSECSHUFFLE:
-        Proc.write_Ci(r[0], Proc.Procp.generate_secure_shuffle(*this,
+        Proc.write_Ci(r[0], Proc.Procp.generate_secure_shuffle(active_inst,
             Proc.machine.shuffle_store));
         return;
       case APPLYSHUFFLE:
-        Proc.Procp.apply_shuffle(*this, Proc.machine.shuffle_store);
+        Proc.Procp.apply_shuffle(active_inst, Proc.machine.shuffle_store);
         return;
       case DELSHUFFLE:
         Proc.machine.shuffle_store.del(Proc.read_Ci(r[0]));
         return;
       case INVPERM:
-        Proc.Procp.inverse_permutation(*this);
+        Proc.Procp.inverse_permutation(active_inst);
         return;
       case CHECK:
         {
@@ -1298,7 +1309,13 @@ inline void Instruction::execute(Processor<sint, sgf2n>& Proc) const
         Proc.machine.join_tape(r[0]);
         break;
       case CALL_TAPE:
-        Proc.call_tape(r[0], Proc.read_Ci(r[1]), start);
+        {
+          int runtime_arg = Proc.read_Ci(r[1]);
+          int caller_arg = Proc.get_arg().get();
+          if (caller_arg < 0)
+            runtime_arg = caller_arg;
+          Proc.call_tape(r[0], runtime_arg, start);
+        }
         break;
       case CRASH:
         if (Proc.read_Ci(r[0]))
@@ -1390,20 +1407,20 @@ inline void Instruction::execute(Processor<sint, sgf2n>& Proc) const
         break;
       case WRITEFILESHARE:
         // Write shares to file system
-        Procp.write_shares_to_file(Proc.read_Ci(r[0]), start, size);
+        Procp.write_shares_to_file(Proc.read_Ci(r[0]), start, active_size);
         return;
       case READFILESHARE:
         // Read shares from file system
-        Procp.read_shares_from_file(Proc.read_Ci(r[0]), r[1], start, size,
+        Procp.read_shares_from_file(Proc.read_Ci(r[0]), r[1], start, active_size,
             Proc);
         return;
       case GWRITEFILESHARE:
         // Write shares to file system
-        Proc2.write_shares_to_file(Proc.read_Ci(r[0]), start, size);
+        Proc2.write_shares_to_file(Proc.read_Ci(r[0]), start, active_size);
         return;
       case GREADFILESHARE:
         // Read shares from file system
-        Proc2.read_shares_from_file(Proc.read_Ci(r[0]), r[1], start, size,
+        Proc2.read_shares_from_file(Proc.read_Ci(r[0]), r[1], start, active_size,
             Proc);
         return;
       case PUBINPUT:
@@ -1429,16 +1446,16 @@ inline void Instruction::execute(Processor<sint, sgf2n>& Proc) const
           }
         break;
       case FIXINPUT:
-        Proc.fixinput(*this);
+        Proc.fixinput(active_inst);
         return;
       case PREP:
-        Procp.DataF.get(Proc.Procp.get_S(), r, start, size);
+        Procp.DataF.get(Proc.Procp.get_S(), r, start, active_size);
         return;
       case GPREP:
-        Proc2.DataF.get(Proc.Proc2.get_S(), r, start, size);
+        Proc2.DataF.get(Proc.Proc2.get_S(), r, start, active_size);
         return;
       case CISC:
-        Procp.protocol.cisc(Procp, *this);
+        Procp.protocol.cisc(Procp, active_inst);
         return;
       default:
         throw invalid_opcode(opcode);
@@ -1460,7 +1477,7 @@ inline void Instruction::execute(Processor<sint, sgf2n>& Proc) const
 #undef X
         throw runtime_error("wrong case statement"); return;
     }
-  if (size > 1)
+  if (active_size > 1)
     {
       r[0]++; r[1]++; r[2]++;
     }
@@ -1504,11 +1521,12 @@ void Program::execute_with_errors(Processor<sint, sgf2n>& Proc) const
   while (Proc.PC<size)
     {
       Proc.last_PC = Proc.PC;
-      auto& instruction = p[Proc.PC];
+      auto instruction = p[Proc.PC];
+      int size = get_effective_vector_size(Proc, instruction.size);
+      instruction.size = size;
       auto& r = instruction.r;
       auto& n = instruction.n;
       auto& start = instruction.start;
-      auto& size = instruction.size;
       (void) start;
 
 #ifdef COUNT_INSTRUCTIONS

--- a/Processor/Processor.hpp
+++ b/Processor/Processor.hpp
@@ -163,7 +163,7 @@ void Processor<sint, sgf2n>::reset(const Program& program,int arg)
   Ci.resize(program.num_reg(INT));
 
   this->arg = arg;
-  Procb.reset(program);
+  Procb.reset(program, arg);
 }
 
 template<class T>
@@ -472,6 +472,8 @@ void SubProcessor<T>::POpen(const Instruction& inst)
     check();
   auto& reg = inst.get_start();
   int size = inst.get_size();
+  if (size == 0)
+    return;
   assert(reg.size() % 2 == 0);
   int sz=reg.size() / 2;
   MC.init_open(P, sz * size);
@@ -553,6 +555,11 @@ void SubProcessor<T>::mulrs(const vector<int>& reg)
 template<class T>
 void SubProcessor<T>::dotprods(const vector<int>& reg, int size)
 {
+    if (size == 0)
+    {
+        maybe_check();
+        return;
+    }
     protocol.init_dotprod();
     for (int i = 0; i < size; i++)
     {


### PR DESCRIPTION
## Description: Runtime Vectorization Length Support
This pull request introduces the ability to execute vectorized instructions and functions based on a runtime-determined length.

While the maximum possible length must still be defined at compile-time to facilitate instruction generation, this change allows for significantly more efficient execution when the actual number of required operations is only known at runtime.

### High-Level API
The functionality is exposed through an extension of the vectorize decorator, which now supports the optional named argument `active_length`.

### Comparison & Motivation
To illustrate the necessity of this change, consider the performance and resource trade-offs of different approaches when processing a fraction of a large array at runtime:

```python
from Compiler.library import *

max_length = 10000
values = Array.create_from([sint(x) for x in range(max_length)])
runtime_length = cint(300)

start_timer(3)
# compare for the whole length and then...
res = values.get_vector().less_than(values.get_vector())
# ...pretend we only use the first runtime_length values in using e.g. @for_range
stop_timer(3)

start_timer(4)
# optimal performance (pretend like we knew the runtime length at compile time)
res = values.get_vector(0, 300).less_than(values.get_vector(0, 300))
stop_timer(4)

@vectorize
def runtime_less_than(a, b):
    return a.less_than(b)

start_timer(5)
# proposed runtime length vectorized instructions solution using a true runtime value
res = runtime_less_than(values.get_vector(), values.get_vector(), active_length=runtime_length)
stop_timer(5)
```

**Current Framework State (Timer 3):** 
To handle dynamic lengths currently, one must process the entire max_length. This introduces no additional compile-time overhead but results in significant data-volume and computation overhead, as unused operations are still executed.

**Manual Mapping (Pre-compilation):** 
Another workaround is "pre-compiling" the vectorized instruction/function for every possible length and mapping them at runtime to the corresponding function. While this avoids data-volume overhead, it causes a compile-time overhead that scales linearly with the maximum possible length.

**The Proposed Solution (Timer 5):** 
By using the `active_length ` parameter, the optimal performance and data-volume of the static baseline (Timer 4) is matched. This eliminates the need to process unused elements without increasing compilation times.

```
Time3 = 0.00544764 seconds (0.383952 MB, 9 rounds)
Time4 = 0.00115694 seconds (0.011596 MB, 9 rounds)
Time5 = 0.00134388 seconds (0.011596 MB, 9 rounds)
```

### Preprocessed Data & Batching
A notable characteristic of this approach is that the exact amount of preprocessed data required is not known at compile-time. To ensure the communication rounds stay as low as the static baseline, the batch size must be adjusted. For the test program above, a batch size of 1,000,000 was used to verify optimal performance; however, users need to tune this value based on their specific requirements when using this feature.

I tried to keep the changes within the Instruction and Processor files as minimal as possible.
Crucially, the standard behavior of the vectorize decorator should remain unchanged when the active_length extension is not utilized.